### PR TITLE
treating the name of a header case-insensitive

### DIFF
--- a/src/main/java/io/vlingo/http/Header.java
+++ b/src/main/java/io/vlingo/http/Header.java
@@ -24,7 +24,7 @@ public class Header {
   }
 
   public boolean matchesName(final Header header) {
-    return name.equals(header.name);
+    return name.equalsIgnoreCase(header.name);
   }
 
   @Override
@@ -40,7 +40,7 @@ public class Header {
 
     final Header otherHeader = (Header) other;
 
-    return name.equals(otherHeader.name) && value.equals(otherHeader.value);
+    return name.equalsIgnoreCase(otherHeader.name) && value.equals(otherHeader.value);
   }
 
   @Override
@@ -71,7 +71,7 @@ public class Header {
       final Iterator<T> iter = this.iterator();
       while (iter.hasNext()) {
         final T header = iter.next();
-        if (header.name.equals(name)) {
+        if (header.name.equalsIgnoreCase(name)) {
           return header;
         }
       }

--- a/src/main/java/io/vlingo/http/Request.java
+++ b/src/main/java/io/vlingo/http/Request.java
@@ -89,7 +89,7 @@ public class Request {
 
   public Header headerOf(final String name) {
     for (final Header header : headers) {
-      if (header.name.equals(name)) {
+      if (header.name.equalsIgnoreCase(name)) {
         return header;
       }
     }

--- a/src/main/java/io/vlingo/http/RequestHeader.java
+++ b/src/main/java/io/vlingo/http/RequestHeader.java
@@ -108,7 +108,7 @@ public class RequestHeader extends Header {
   }
 
   int ifContentLength() {
-    if (name.equals(ContentLength)) {
+    if (name.equalsIgnoreCase(ContentLength)) {
       return Integer.parseInt(value);
     }
     return 0;

--- a/src/main/java/io/vlingo/http/Response.java
+++ b/src/main/java/io/vlingo/http/Response.java
@@ -61,7 +61,7 @@ public class Response {
 
   public Header headerOf(final String name) {
     for (final Header header : headers) {
-      if (header.name.equals(name)) {
+      if (header.name.equalsIgnoreCase(name)) {
         return header;
       }
     }

--- a/src/main/java/io/vlingo/http/ResponseHeader.java
+++ b/src/main/java/io/vlingo/http/ResponseHeader.java
@@ -120,7 +120,7 @@ public class ResponseHeader extends Header {
   }
 
   int ifContentLength() {
-    if (name.equals(ContentLength)) {
+    if (name.equalsIgnoreCase(ContentLength)) {
       return Integer.parseInt(value);
     }
     return 0;

--- a/src/test/java/io/vlingo/http/RequestHeaderTest.java
+++ b/src/test/java/io/vlingo/http/RequestHeaderTest.java
@@ -36,7 +36,22 @@ public class RequestHeaderTest {
     assertEquals(RequestHeader.Accept, header.name);
     assertEquals("text/plain", header.value);
   }
-  
+
+  @Test
+  public void testParseLowerCaseContentLength() {
+    final RequestHeader header = RequestHeader.from("content-length: 10");
+
+    assertEquals(10, header.ifContentLength());
+  }
+
+  @Test
+  public void testEqualsCaseInsensitive() {
+    final RequestHeader header1 = RequestHeader.from("Content-length: 10");
+    final RequestHeader header2 = RequestHeader.from("content-length: 10");
+
+    assertEquals(header1, header2);
+  }
+
   @Test
   public void testParseHeaderWithMultipleValueStrings() {
     final RequestHeader header = RequestHeader.from("Cookie: $Version=1; Skin=new;");


### PR DESCRIPTION
This replaces the relevant .equals() with .equalsIgnorecase()

It also adds two new test cases for case-insensitive header handling. 

Please double check if other code instances need to be changed or more test cases are necessary.

closes #8