### PR TITLE
Requests with additional path elements should not match

### DIFF
--- a/src/main/java/io/vlingo/http/resource/Action.java
+++ b/src/main/java/io/vlingo/http/resource/Action.java
@@ -62,6 +62,14 @@ public final class Action {
     return new MappedParameters(this.id, this.method, to.methodName, mapped);
   }
 
+  int indexOfNextSegmentStart(int currentIndex, String path) {
+    int nextSegmentStart = path.indexOf("/", currentIndex+1);
+    if (nextSegmentStart < currentIndex) {
+      return path.length();
+    }
+    return nextSegmentStart;
+  }
+
   MatchResults matchWith(final Method method, final URI uri) {
     if (this.method.equals(method)) {
       final String path = uri.getPath();
@@ -72,7 +80,7 @@ public final class Action {
         final PathSegment segment = matchable.pathSegment(idx);
         if (segment.isPathParameter()) {
           running.keepParameterSegment(pathCurrentIndex);
-          ++pathCurrentIndex;
+          pathCurrentIndex = indexOfNextSegmentStart(pathCurrentIndex, path);
         } else {
           final int indexOfSegment = path.indexOf(segment.value, pathCurrentIndex);
           if (indexOfSegment == -1 || (pathCurrentIndex == 0 && indexOfSegment != 0)) {
@@ -82,6 +90,9 @@ public final class Action {
           running.keepPathSegment(indexOfSegment, lastIndex);
           pathCurrentIndex = lastIndex;
         }
+      }
+      if (indexOfNextSegmentStart(pathCurrentIndex, path) != path.length()) {
+        return unmatchedResults;
       }
       final MatchResults matchResults = new MatchResults(this, running, parameterNames(), path, disallowPathParametersWithSlash);
       return matchResults;

--- a/src/main/java/io/vlingo/http/resource/Action.java
+++ b/src/main/java/io/vlingo/http/resource/Action.java
@@ -62,8 +62,8 @@ public final class Action {
     return new MappedParameters(this.id, this.method, to.methodName, mapped);
   }
 
-  int indexOfNextSegmentStart(int currentIndex, String path) {
-    int nextSegmentStart = path.indexOf("/", currentIndex+1);
+  private int indexOfNextSegmentStart(int currentIndex, String path) {
+    int nextSegmentStart = path.indexOf("/", currentIndex);
     if (nextSegmentStart < currentIndex) {
       return path.length();
     }
@@ -91,8 +91,11 @@ public final class Action {
           pathCurrentIndex = lastIndex;
         }
       }
-      if (indexOfNextSegmentStart(pathCurrentIndex, path) != path.length()) {
-        return unmatchedResults;
+      int nextPathSegmentIndex = indexOfNextSegmentStart(pathCurrentIndex, path);
+      if ( nextPathSegmentIndex != path.length()) {
+        if (disallowPathParametersWithSlash || nextPathSegmentIndex < path.length() - 1) {
+          return unmatchedResults;
+        }
       }
       final MatchResults matchResults = new MatchResults(this, running, parameterNames(), path, disallowPathParametersWithSlash);
       return matchResults;

--- a/src/test/java/io/vlingo/http/resource/ActionTest.java
+++ b/src/test/java/io/vlingo/http/resource/ActionTest.java
@@ -99,7 +99,7 @@ public class ActionTest {
   }
 
   @Test
-  public void testMatchesMutipleParametersWithEndSlash() throws Exception {
+  public void testMatchesMultipleParametersWithEndSlash() throws Exception {
     final Action action =
             new Action(
                     0,
@@ -141,6 +141,40 @@ public class ActionTest {
     assertNull(matchResults.action);
     assertEquals(0, matchResults.parameterCount());
   }
+
+  @Test
+  public void testNoMatchGivenAdditionalElements() throws Exception {
+    final Action action = new Action(0, "GET", "/users/{id}", "queryUsers(String userId)", null, false);
+
+    final MatchResults matchResults = action.matchWith(Method.GET, new URI("/users/1234/extra"));
+
+    assertFalse(matchResults.isMatched());
+    assertNull(matchResults.action);
+    assertEquals(0, matchResults.parameterCount());
+  }
+
+  @Test
+  public void testNoMatchEmptyParam() throws Exception {
+    final Action action = new Action(0, "GET", "/users/{id}/data", "queryUserData(String userId)", null, true);
+
+    final MatchResults matchResults = action.matchWith(Method.GET, new URI("/users//data"));
+
+    assertFalse(matchResults.isMatched());
+    assertSame(action, matchResults.action);
+    assertEquals(0, matchResults.parameterCount());
+  }
+
+  @Test
+  public void testMatchEmptyParamGivenAllowsTrailingSlash() throws Exception {
+    final Action action = new Action(0, "GET", "/users/{id}", "queryUsers(String userId)", null, false);
+
+    final MatchResults matchResults = action.matchWith(Method.GET, new URI("/users//"));
+
+    assertTrue(matchResults.isMatched());
+    assertSame(action, matchResults.action);
+    assertEquals(1, matchResults.parameterCount());
+  }
+
 
   @Test
   public void testNoMatchMultipleParametersMissingSlash() throws Exception {

--- a/src/test/java/io/vlingo/http/resource/ResourceBuilderTest.java
+++ b/src/test/java/io/vlingo/http/resource/ResourceBuilderTest.java
@@ -22,6 +22,7 @@ import static io.vlingo.http.Response.Status.Ok;
 import static io.vlingo.http.resource.ResourceBuilder.*;
 import static io.vlingo.http.resource.serialization.JsonSerialization.serialized;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 public class ResourceBuilderTest extends ResourceTestFixtures {
@@ -64,6 +65,22 @@ public class ResourceBuilderTest extends ResourceTestFixtures {
 
     assertEquals("/customers/{customerId}/accounts/{accountId}/withdraw", matchWithdrawResource.action.uri);
     assertEquals("/customers/{customerId}/accounts/{accountId}", matchAccountResource.action.uri);
+  }
+
+
+  @Test
+  public void shouldNotRespondToResourceHandler_whenPathDoesNotMatch() throws URISyntaxException {
+    final DynamicResource resource = (DynamicResource) resource("userResource",
+      post("/customers/{customerId}")
+        .param(String.class)
+        .handle((customerId) -> Completes.withSuccess((Response.of(Ok, serialized("users")))))
+      );
+
+    final Action.MatchResults matchWithdrawResource = resource.matchWith(
+      Method.POST,
+      new URI("/customers/cd1234/accounts/ac1234/withdraw"));
+
+    assertFalse(matchWithdrawResource.matched);
   }
 
 }

--- a/src/test/java/io/vlingo/http/resource/ResourceBuilderTest.java
+++ b/src/test/java/io/vlingo/http/resource/ResourceBuilderTest.java
@@ -22,7 +22,6 @@ import static io.vlingo.http.Response.Status.Ok;
 import static io.vlingo.http.resource.ResourceBuilder.*;
 import static io.vlingo.http.resource.serialization.JsonSerialization.serialized;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 public class ResourceBuilderTest extends ResourceTestFixtures {
@@ -65,22 +64,6 @@ public class ResourceBuilderTest extends ResourceTestFixtures {
 
     assertEquals("/customers/{customerId}/accounts/{accountId}/withdraw", matchWithdrawResource.action.uri);
     assertEquals("/customers/{customerId}/accounts/{accountId}", matchAccountResource.action.uri);
-  }
-
-
-  @Test
-  public void shouldNotRespondToResourceHandler_whenPathDoesNotMatch() throws URISyntaxException {
-    final DynamicResource resource = (DynamicResource) resource("userResource",
-      post("/customers/{customerId}")
-        .param(String.class)
-        .handle((customerId) -> Completes.withSuccess((Response.of(Ok, serialized("users")))))
-      );
-
-    final Action.MatchResults matchWithdrawResource = resource.matchWith(
-      Method.POST,
-      new URI("/customers/cd1234/accounts/ac1234/withdraw"));
-
-    assertFalse(matchWithdrawResource.matched);
   }
 
 }


### PR DESCRIPTION
Hi @VaughnVernon ,

This is a PR for the issue related to resource paths matching where they should not match.  I think the code could be simplified, but I'm proposing a simple fix that just checks if there are more path elements remaining:
eg: /foo/{id} with request /foo/1234/bar should not cause a match
