### PR TITLE
Error handler improvement to RequestHandlers and ResourceRequestHandler

### DIFF
--- a/src/main/java/io/vlingo/http/resource/ConfigurationResource.java
+++ b/src/main/java/io/vlingo/http/resource/ConfigurationResource.java
@@ -21,7 +21,7 @@ import io.vlingo.http.resource.Action.MatchResults;
 import io.vlingo.http.resource.ResourceDispatcherGenerator.Result;
 
 public abstract class ConfigurationResource<T> extends Resource<T> {
-  static final String DispatcherPostixName = "Dispatcher";
+  static final String DispatcherSuffix = "Dispatcher";
 
   private static DynaClassLoader classLoader = new DynaClassLoader(ConfigurationResource.class.getClassLoader());
   private static final DynaCompiler dynaCompiler = new DynaCompiler();
@@ -47,7 +47,7 @@ public abstract class ConfigurationResource<T> extends Resource<T> {
     assertSaneActions(actions);
 
     try {
-      final String targetClassname = resourceHandlerClass.getName() + DispatcherPostixName;
+      final String targetClassname = resourceHandlerClass.getName() + DispatcherSuffix;
 
       Class<ConfigurationResource<?>> resourceClass = null;
       try {
@@ -60,8 +60,8 @@ public abstract class ConfigurationResource<T> extends Resource<T> {
       final Object[] ctorParams = new Object[] { resourceName, resourceHandlerClass, handlerPoolSize, actions };
       for (final Constructor<?> ctor : resourceClass.getConstructors()) {
         if (ctor.getParameterCount() == ctorParams.length) {
-          final ConfigurationResource<?> resourecDispatcher = (ConfigurationResource<?>) ctor.newInstance(ctorParams);
-          return resourecDispatcher;
+          final ConfigurationResource<?> resourceDispatcher = (ConfigurationResource<?>) ctor.newInstance(ctorParams);
+          return resourceDispatcher;
         }
       }
       return resourceClass.newInstance();

--- a/src/main/java/io/vlingo/http/resource/ErrorHandler.java
+++ b/src/main/java/io/vlingo/http/resource/ErrorHandler.java
@@ -1,0 +1,12 @@
+package io.vlingo.http.resource;
+
+import io.vlingo.common.Completes;
+import io.vlingo.http.Response;
+
+public interface ErrorHandler {
+  Completes<Response> handle(Throwable error);
+
+  static ErrorHandler handleAllWith(Response.Status status) {
+    return error -> Completes.withSuccess(Response.of(status));
+  }
+}

--- a/src/main/java/io/vlingo/http/resource/RequestHandler2.java
+++ b/src/main/java/io/vlingo/http/resource/RequestHandler2.java
@@ -21,19 +21,22 @@ public class RequestHandler2<T, R> extends RequestHandler {
   final ParameterResolver<T> resolverParam1;
   final ParameterResolver<R> resolverParam2;
   private Handler2<T, R> handler;
+  private ErrorHandler errorHandler;
 
   RequestHandler2(final Method method,
                   final String path,
                   final ParameterResolver<T> resolverParam1,
-                  final ParameterResolver<R> resolverParam2) {
+                  final ParameterResolver<R> resolverParam2,
+                  final ErrorHandler errorHandler) {
     super(method, path, Arrays.asList(resolverParam1, resolverParam2));
     this.resolverParam1 = resolverParam1;
     this.resolverParam2 = resolverParam2;
+    this.errorHandler = errorHandler;
   }
 
   Completes<Response> execute(final T param1, final R param2) {
-    if (handler == null) throw new HandlerMissingException("No handle defined for " + method.toString() + " " + path);
-    return handler.execute(param1, param2);
+    checkHandlerOrThrowException(handler);
+    return executeRequest(() -> handler.execute(param1, param2), errorHandler);
   }
 
   public RequestHandler2<T, R> handle(final Handler2<T, R> handler) {
@@ -41,9 +44,14 @@ public class RequestHandler2<T, R> extends RequestHandler {
     return this;
   }
 
+  public RequestHandler2<T, R> onError(ErrorHandler errorHandler) {
+    this.errorHandler = errorHandler;
+    return this;
+  }
+
   @Override
   public Completes<Response> execute(final Request request,
-                           final Action.MappedParameters mappedParameters) {
+                                     final Action.MappedParameters mappedParameters) {
     final T param1 = resolverParam1.apply(request, mappedParameters);
     final R param2 = resolverParam2.apply(request, mappedParameters);
     return execute(param1, param2);
@@ -56,11 +64,11 @@ public class RequestHandler2<T, R> extends RequestHandler {
 
   // region FluentAPI
   public <U> RequestHandler3<T, R, U> param(final Class<U> paramClass) {
-    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2, ParameterResolver.path(2, paramClass));
+    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2, ParameterResolver.path(2, paramClass), errorHandler);
   }
 
   public <U> RequestHandler3<T, R, U> body(final Class<U> bodyClass) {
-    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2, ParameterResolver.body(bodyClass));
+    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2, ParameterResolver.body(bodyClass), errorHandler);
   }
 
   public <U> RequestHandler3<T, R, U> body(final Class<U> bodyClass, final Class<? extends Mapper> mapperClass) {
@@ -69,7 +77,7 @@ public class RequestHandler2<T, R> extends RequestHandler {
 
   public <U> RequestHandler3<T, R, U> body(final Class<U> bodyClass, final Mapper mapper) {
     return new RequestHandler3<>(method, path, resolverParam1, resolverParam2,
-      ParameterResolver.body(bodyClass, mapper));
+      ParameterResolver.body(bodyClass, mapper), errorHandler);
   }
 
   public RequestHandler3<T, R, String> query(final String name) {
@@ -77,11 +85,11 @@ public class RequestHandler2<T, R> extends RequestHandler {
   }
 
   public <U> RequestHandler3<T, R, U> query(final String name, final Class<U> queryClass) {
-    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2, ParameterResolver.query(name, queryClass));
+    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2, ParameterResolver.query(name, queryClass), errorHandler);
   }
 
   public RequestHandler3<T, R, Header> header(final String name) {
-    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2, ParameterResolver.header(name));
+    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2, ParameterResolver.header(name), errorHandler);
   }
   // endregion
 }

--- a/src/main/java/io/vlingo/http/resource/RequestHandler3.java
+++ b/src/main/java/io/vlingo/http/resource/RequestHandler3.java
@@ -13,25 +13,33 @@ public class RequestHandler3<T, R, U> extends RequestHandler {
   final ParameterResolver<R> resolverParam2;
   final ParameterResolver<U> resolverParam3;
   private Handler3<T, R, U> handler;
+  private ErrorHandler errorHandler;
 
   RequestHandler3(final Method method,
                   final String path,
                   final ParameterResolver<T> resolverParam1,
                   final ParameterResolver<R> resolverParam2,
-                  final ParameterResolver<U> resolverParam3) {
+                  final ParameterResolver<U> resolverParam3,
+                  ErrorHandler errorHandler) {
     super(method, path, Arrays.asList(resolverParam1, resolverParam2, resolverParam3));
     this.resolverParam1 = resolverParam1;
     this.resolverParam2 = resolverParam2;
     this.resolverParam3 = resolverParam3;
+    this.errorHandler = errorHandler;
   }
 
   Completes<Response> execute(final T param1, final R param2, final U param3) {
-    if (handler == null) throw new HandlerMissingException("No handle defined for " + method.toString() + " " + path);
-    return handler.execute(param1, param2, param3);
+    checkHandlerOrThrowException(handler);
+    return executeRequest(() -> handler.execute(param1, param2, param3), errorHandler);
   }
 
   public RequestHandler3<T, R, U> handle(final Handler3<T, R, U> handler) {
     this.handler = handler;
+    return this;
+  }
+
+  public RequestHandler3<T, R, U> onError(ErrorHandler errorHandler) {
+    this.errorHandler = errorHandler;
     return this;
   }
 
@@ -50,11 +58,15 @@ public class RequestHandler3<T, R, U> extends RequestHandler {
 
   // region FluentAPI
   public <I> RequestHandler4<T, R, U, I> param(final Class<I> paramClass) {
-    return new RequestHandler4<>(method, path, resolverParam1, resolverParam2, resolverParam3, ParameterResolver.path(3, paramClass));
+    return new RequestHandler4<>(method, path, resolverParam1, resolverParam2, resolverParam3,
+      ParameterResolver.path(3, paramClass),
+      errorHandler);
   }
 
   public <I> RequestHandler4<T, R, U, I> body(final Class<I> bodyClass) {
-    return new RequestHandler4<>(method, path, resolverParam1, resolverParam2, resolverParam3, ParameterResolver.body(bodyClass));
+    return new RequestHandler4<>(method, path, resolverParam1, resolverParam2, resolverParam3,
+      ParameterResolver.body(bodyClass),
+      errorHandler);
   }
 
   public <I> RequestHandler4<T, R, U, I> body(final Class<I> bodyClass, final Class<? extends Mapper> mapperClass) {
@@ -63,7 +75,8 @@ public class RequestHandler3<T, R, U> extends RequestHandler {
 
   public <I> RequestHandler4<T, R, U, I> body(final Class<I> bodyClass, final Mapper mapper) {
     return new RequestHandler4<>(method, path, resolverParam1, resolverParam2, resolverParam3,
-      ParameterResolver.body(bodyClass, mapper));
+      ParameterResolver.body(bodyClass, mapper),
+      errorHandler);
   }
 
   public RequestHandler4<T, R, U, String> query(final String name) {
@@ -71,11 +84,15 @@ public class RequestHandler3<T, R, U> extends RequestHandler {
   }
 
   public <I> RequestHandler4<T, R, U, I> query(final String name, final Class<I> queryClass) {
-    return new RequestHandler4<>(method, path, resolverParam1, resolverParam2, resolverParam3, ParameterResolver.query(name, queryClass));
+    return new RequestHandler4<>(method, path, resolverParam1, resolverParam2, resolverParam3,
+      ParameterResolver.query(name, queryClass),
+      errorHandler);
   }
 
   public RequestHandler4<T, R, U, Header> header(final String name) {
-    return new RequestHandler4<>(method, path, resolverParam1, resolverParam2, resolverParam3, ParameterResolver.header(name));
+    return new RequestHandler4<>(method, path, resolverParam1, resolverParam2, resolverParam3,
+      ParameterResolver.header(name),
+      errorHandler);
   }
   // endregion
 }

--- a/src/main/java/io/vlingo/http/resource/RequestHandler4.java
+++ b/src/main/java/io/vlingo/http/resource/RequestHandler4.java
@@ -14,27 +14,35 @@ public class RequestHandler4<T, R, U, I> extends RequestHandler {
   final ParameterResolver<U> resolverParam3;
   final ParameterResolver<I> resolverParam4;
   private Handler4<T, R, U, I> handler;
+  private ErrorHandler errorHandler;
 
   RequestHandler4(final Method method,
                   final String path,
                   final ParameterResolver<T> resolverParam1,
                   final ParameterResolver<R> resolverParam2,
                   final ParameterResolver<U> resolverParam3,
-                  final ParameterResolver<I> resolverParam4) {
+                  final ParameterResolver<I> resolverParam4,
+                  final ErrorHandler errorHandler) {
     super(method, path, Arrays.asList(resolverParam1, resolverParam2, resolverParam3, resolverParam4));
     this.resolverParam1 = resolverParam1;
     this.resolverParam2 = resolverParam2;
     this.resolverParam3 = resolverParam3;
     this.resolverParam4 = resolverParam4;
+    this.errorHandler = errorHandler;
   }
 
   Completes<Response> execute(final T param1, final R param2, final U param3, final I param4) {
-    if (handler == null) throw new HandlerMissingException("No handle defined for " + method.toString() + " " + path);
-    return handler.execute(param1, param2, param3, param4);
+    checkHandlerOrThrowException(handler);
+    return executeRequest(() -> handler.execute(param1, param2, param3, param4), errorHandler);
   }
 
   public RequestHandler4<T, R, U, I> handle(final Handler4<T, R, U, I> handler) {
     this.handler = handler;
+    return this;
+  }
+
+  public RequestHandler4<T, R, U, I> onError(ErrorHandler errorHandler) {
+    this.errorHandler = errorHandler;
     return this;
   }
 
@@ -54,11 +62,15 @@ public class RequestHandler4<T, R, U, I> extends RequestHandler {
 
   // region FluentAPI
   public <J> RequestHandler5<T, R, U, I, J> param(final Class<J> paramClass) {
-    return new RequestHandler5<>(method, path, resolverParam1, resolverParam2, resolverParam3, resolverParam4, ParameterResolver.path(4, paramClass));
+    return new RequestHandler5<>(method, path, resolverParam1, resolverParam2, resolverParam3, resolverParam4,
+      ParameterResolver.path(4, paramClass),
+      errorHandler);
   }
 
   public <J> RequestHandler5<T, R, U, I, J> body(final Class<J> bodyClass) {
-    return new RequestHandler5<>(method, path, resolverParam1, resolverParam2, resolverParam3, resolverParam4, ParameterResolver.body(bodyClass));
+    return new RequestHandler5<>(method, path, resolverParam1, resolverParam2, resolverParam3, resolverParam4,
+      ParameterResolver.body(bodyClass),
+      errorHandler);
   }
 
   public <J> RequestHandler5<T, R, U, I, J> body(final Class<J> bodyClass, final Class<? extends Mapper> mapperClass) {
@@ -67,7 +79,8 @@ public class RequestHandler4<T, R, U, I> extends RequestHandler {
 
   public <J> RequestHandler5<T, R, U, I, J> body(final Class<J> bodyClass, final Mapper mapper) {
     return new RequestHandler5<>(method, path, resolverParam1, resolverParam2, resolverParam3, resolverParam4,
-      ParameterResolver.body(bodyClass, mapper));
+      ParameterResolver.body(bodyClass, mapper),
+      errorHandler);
   }
 
   public RequestHandler5<T, R, U, I, String> query(final String name) {
@@ -75,11 +88,15 @@ public class RequestHandler4<T, R, U, I> extends RequestHandler {
   }
 
   public <J> RequestHandler5<T, R, U, I, J> query(final String name, final Class<J> queryClass) {
-    return new RequestHandler5<>(method, path, resolverParam1, resolverParam2, resolverParam3, resolverParam4, ParameterResolver.query(name, queryClass));
+    return new RequestHandler5<>(method, path, resolverParam1, resolverParam2, resolverParam3, resolverParam4,
+      ParameterResolver.query(name, queryClass),
+      errorHandler);
   }
 
   public RequestHandler5<T, R, U, I, Header> header(final String name) {
-    return new RequestHandler5<>(method, path, resolverParam1, resolverParam2, resolverParam3, resolverParam4, ParameterResolver.header(name));
+    return new RequestHandler5<>(method, path, resolverParam1, resolverParam2, resolverParam3, resolverParam4,
+      ParameterResolver.header(name),
+      errorHandler);
   }
   // endregion
 }

--- a/src/main/java/io/vlingo/http/resource/RequestHandler5.java
+++ b/src/main/java/io/vlingo/http/resource/RequestHandler5.java
@@ -14,6 +14,7 @@ public class RequestHandler5<T, R, U, I, J> extends RequestHandler {
   final ParameterResolver<I> resolverParam4;
   final ParameterResolver<J> resolverParam5;
   private Handler5<T, R, U, I, J> handler;
+  private ErrorHandler errorHandler;
 
   RequestHandler5(final Method method,
                   final String path,
@@ -21,22 +22,29 @@ public class RequestHandler5<T, R, U, I, J> extends RequestHandler {
                   final ParameterResolver<R> resolverParam2,
                   final ParameterResolver<U> resolverParam3,
                   final ParameterResolver<I> resolverParam4,
-                  final ParameterResolver<J> resolverParam5) {
+                  final ParameterResolver<J> resolverParam5,
+                  final ErrorHandler errorHandler) {
     super(method, path, Arrays.asList(resolverParam1, resolverParam2, resolverParam3, resolverParam4, resolverParam5));
     this.resolverParam1 = resolverParam1;
     this.resolverParam2 = resolverParam2;
     this.resolverParam3 = resolverParam3;
     this.resolverParam4 = resolverParam4;
     this.resolverParam5 = resolverParam5;
+    this.errorHandler = errorHandler;
   }
 
   Completes<Response> execute(final T param1, final R param2, final U param3, final I param4, final J param5) {
-    if (handler == null) throw new HandlerMissingException("No handle defined for " + method.toString() + " " + path);
-    return handler.execute(param1, param2, param3, param4, param5);
+    checkHandlerOrThrowException(handler);
+    return executeRequest(() -> handler.execute(param1, param2, param3, param4, param5), errorHandler);
   }
 
   public RequestHandler5<T, R, U, I, J> handle(final Handler5<T, R, U, I, J> handler) {
     this.handler = handler;
+    return this;
+  }
+
+  public RequestHandler5<T, R, U, I, J> onError(ErrorHandler errorHandler) {
+    this.errorHandler = errorHandler;
     return this;
   }
 

--- a/src/main/java/io/vlingo/http/resource/ResourceDispatcherGenerator.java
+++ b/src/main/java/io/vlingo/http/resource/ResourceDispatcherGenerator.java
@@ -78,10 +78,10 @@ public class ResourceDispatcherGenerator implements AutoCloseable {
       try {
         final Class<?> handlerInterface = readHandlerInterface(handlerProtocol);
         final String dispatcherClassSource = dispatcherClassSource(handlerInterface);
-        final String fullyQualifiedClassname = fullyQualifiedClassnameFor(handlerInterface, ConfigurationResource.DispatcherPostixName);
+        final String fullyQualifiedClassname = fullyQualifiedClassnameFor(handlerInterface, ConfigurationResource.DispatcherSuffix);
         final String relativeTargetFile = toFullPath(fullyQualifiedClassname);
         final File sourceFile = persist ? persistDispatcherClassSource(handlerProtocol, relativeTargetFile, dispatcherClassSource) : new File(relativeTargetFile);
-        return new Result(fullyQualifiedClassname, classnameFor(handlerInterface, ConfigurationResource.DispatcherPostixName), dispatcherClassSource, sourceFile);
+        return new Result(fullyQualifiedClassname, classnameFor(handlerInterface, ConfigurationResource.DispatcherSuffix), dispatcherClassSource, sourceFile);
       } catch (Exception e) {
         throw new IllegalArgumentException("Cannot generate resource dispatcher class for: " + handlerProtocol, e);
       }
@@ -139,13 +139,13 @@ public class ResourceDispatcherGenerator implements AutoCloseable {
   }
 
   private String classStatement(final Class<?> handlerInterface) {
-    return MessageFormat.format("public class {0} extends ConfigurationResource<{1}> '{'\n", classnameFor(handlerInterface, ConfigurationResource.DispatcherPostixName), handlerInterface.getSimpleName());
+    return MessageFormat.format("public class {0} extends ConfigurationResource<{1}> '{'\n", classnameFor(handlerInterface, ConfigurationResource.DispatcherSuffix), handlerInterface.getSimpleName());
   }
 
   private String constructor(final Class<?> protocolInterface) {
     final StringBuilder builder = new StringBuilder();
 
-    final String signature0 = MessageFormat.format("  public {0}(\n", classnameFor(protocolInterface, ConfigurationResource.DispatcherPostixName));
+    final String signature0 = MessageFormat.format("  public {0}(\n", classnameFor(protocolInterface, ConfigurationResource.DispatcherSuffix));
     final String signature1 = "          final String name,\n";
     final String signature2 = "          final Class<? extends ResourceHandler> resourceHandlerClass,\n";
     final String signature3 = "          final int handlerPoolSize,\n";

--- a/src/main/java/io/vlingo/http/resource/ResourceRequestHandlerActor.java
+++ b/src/main/java/io/vlingo/http/resource/ResourceRequestHandlerActor.java
@@ -26,8 +26,11 @@ public class ResourceRequestHandlerActor extends Actor implements ResourceReques
       resourceHandler.context = context;
       resourceHandler.stage = stage();
       consumer.accept(resourceHandler);
-    }catch (Throwable throwable) {
-      logger().log("Exception raised from resource dispatcher", throwable);
+    }catch (Error throwable) {
+      logger().log("Error thrown by resource dispatcher", throwable);
+      context.completes.with(Response.of(Response.Status.InternalServerError));
+    }catch (RuntimeException exception) {
+      logger().log("Runtime thrown by resource dispatcher", exception);
       context.completes.with(Response.of(Response.Status.InternalServerError));
     }
   }

--- a/src/main/java/io/vlingo/http/resource/ResourceRequestHandlerActor.java
+++ b/src/main/java/io/vlingo/http/resource/ResourceRequestHandlerActor.java
@@ -11,6 +11,7 @@ import java.util.function.Consumer;
 
 import io.vlingo.actors.Actor;
 import io.vlingo.http.Context;
+import io.vlingo.http.Response;
 
 public class ResourceRequestHandlerActor extends Actor implements ResourceRequestHandler {
   private final ResourceHandler resourceHandler;
@@ -21,8 +22,13 @@ public class ResourceRequestHandlerActor extends Actor implements ResourceReques
 
   @SuppressWarnings({ "rawtypes", "unchecked" })
   public void handleFor(final Context context, final Consumer consumer) {
-    resourceHandler.context = context;
-    resourceHandler.stage = stage();
-    consumer.accept(resourceHandler);
+    try {
+      resourceHandler.context = context;
+      resourceHandler.stage = stage();
+      consumer.accept(resourceHandler);
+    }catch (Throwable throwable) {
+      logger().log("Exception raised from resource dispatcher", throwable);
+      context.completes.with(Response.of(Response.Status.InternalServerError));
+    }
   }
 }

--- a/src/test/java/io/vlingo/http/resource/ConfigurationResourceTest.java
+++ b/src/test/java/io/vlingo/http/resource/ConfigurationResourceTest.java
@@ -238,7 +238,7 @@ public class ConfigurationResourceTest extends ResourceTestFixtures {
     // a better ordering of actions and one that does not use the
     // disallowPathParametersWithSlash option.
     // See also: vlingo-http.properties
-    //   resource.NAME.disallowPathParametersWithSlash = true/false
+    //   userResource.NAME.disallowPathParametersWithSlash = true/false
     //=============================================================
     
     final List<Action> actions =

--- a/src/test/java/io/vlingo/http/resource/RequestHandler0Test.java
+++ b/src/test/java/io/vlingo/http/resource/RequestHandler0Test.java
@@ -9,31 +9,23 @@
 
 package io.vlingo.http.resource;
 
-import static io.vlingo.common.Completes.withSuccess;
-import static io.vlingo.http.Response.of;
-import static io.vlingo.http.Response.Status.Created;
-import static io.vlingo.http.resource.ParameterResolver.body;
-import static io.vlingo.http.resource.ParameterResolver.header;
-import static io.vlingo.http.resource.ParameterResolver.path;
-import static io.vlingo.http.resource.ParameterResolver.query;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import java.net.URI;
-import java.util.Collections;
-
+import io.vlingo.common.Completes;
+import io.vlingo.http.*;
+import io.vlingo.http.sample.user.NameData;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import io.vlingo.http.Body;
-import io.vlingo.http.Header;
-import io.vlingo.http.Method;
-import io.vlingo.http.Request;
-import io.vlingo.http.RequestHeader;
-import io.vlingo.http.Response;
-import io.vlingo.http.Version;
-import io.vlingo.http.sample.user.NameData;
+import java.net.URI;
+import java.util.Collections;
+
+import static io.vlingo.common.Completes.withSuccess;
+import static io.vlingo.http.Response.Status.Created;
+import static io.vlingo.http.Response.Status.Imateapot;
+import static io.vlingo.http.Response.of;
+import static io.vlingo.http.resource.ParameterResolver.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class RequestHandler0Test extends RequestHandlerTestBase {
   @Rule
@@ -52,13 +44,16 @@ public class RequestHandler0Test extends RequestHandlerTestBase {
   }
 
   @Test
-  public void throwExceptionWhenNoHandlerIsDefined() {
-    thrown.expect(HandlerMissingException.class);
-    thrown.expectMessage("No handle defined for GET /helloworld");
-
-    final RequestHandler0 handler = new RequestHandler0(Method.GET, "/helloworld");
-
-    handler.execute();
+  public void errorHandlerInvoked() {
+    final RequestHandler0 handler = new RequestHandler0(Method.GET, "/helloworld")
+      .handle(() -> {
+        throw new RuntimeException("Test Handler exception");
+      })
+      .onError(
+      error -> Completes.withSuccess(Response.of(Response.Status.Imateapot))
+    );
+    Completes<Response> responseCompletes = handler.execute();
+    assertResponsesAreEquals(Response.of(Imateapot), responseCompletes.await());
   }
 
   @Test

--- a/src/test/java/io/vlingo/http/resource/RequestHandler5Test.java
+++ b/src/test/java/io/vlingo/http/resource/RequestHandler5Test.java
@@ -9,6 +9,7 @@
 
 package io.vlingo.http.resource;
 
+import io.vlingo.common.Completes;
 import io.vlingo.http.Method;
 import io.vlingo.http.Request;
 import io.vlingo.http.Response;
@@ -21,7 +22,7 @@ import java.net.URI;
 import java.util.Arrays;
 
 import static io.vlingo.common.Completes.withSuccess;
-import static io.vlingo.http.Response.Status.Ok;
+import static io.vlingo.http.Response.Status.*;
 import static io.vlingo.http.Response.of;
 import static io.vlingo.http.resource.ParameterResolver.path;
 import static io.vlingo.http.resource.ParameterResolver.query;
@@ -33,9 +34,27 @@ public class RequestHandler5Test extends RequestHandlerTestBase {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
+  private <T, R, U, I, J> RequestHandler5<T, R, U, I, J> createRequestHandler(Method method,
+                                                                              String path,
+                                                                              ParameterResolver<T> parameterResolver1,
+                                                                              ParameterResolver<R> parameterResolver2,
+                                                                              ParameterResolver<U> parameterResolver3,
+                                                                              ParameterResolver<I> parameterResolver4,
+                                                                              ParameterResolver<J> parameterResolver5) {
+    return new RequestHandler5<>(
+      method,
+      path,
+      parameterResolver1,
+      parameterResolver2,
+      parameterResolver3,
+      parameterResolver4,
+      parameterResolver5,
+      ErrorHandler.handleAllWith(InternalServerError));
+  }
+
   @Test
   public void handlerWithOneParam() {
-    final RequestHandler5<String, String, String, Integer, Integer> handler = new RequestHandler5<>(
+    final RequestHandler5<String, String, String, Integer, Integer> handler = createRequestHandler(
       Method.GET,
       "/posts/{postId}/comment/{commentId}/user/{userId}",
       path(0, String.class),
@@ -60,7 +79,7 @@ public class RequestHandler5Test extends RequestHandlerTestBase {
     thrown.expect(HandlerMissingException.class);
     thrown.expectMessage("No handle defined for GET /posts/{postId}");
 
-    final RequestHandler5<String, String, String, Integer, Integer> handler = new RequestHandler5<>(
+    final RequestHandler5<String, String, String, Integer, Integer> handler = createRequestHandler(
       Method.GET,
       "/posts/{postId}/comment/{commentId}/user/{userId}",
       path(0, String.class),
@@ -73,8 +92,26 @@ public class RequestHandler5Test extends RequestHandlerTestBase {
   }
 
   @Test
+  public void errorHandlerInvoked() {
+    final RequestHandler5<String, String, String, Integer, Integer> handler = createRequestHandler(
+      Method.GET,
+      "/posts/{postId}/comment/{commentId}/user/{userId}",
+      path(0, String.class),
+      path(1, String.class),
+      path(2, String.class),
+      query("page", Integer.class, 10),
+      query("pageSize", Integer.class, 10))
+      .handle((param1, param2, param3, param4, param5) -> { throw new RuntimeException("Test Handler exception"); })
+      .onError(
+        error -> Completes.withSuccess(Response.of(Response.Status.Imateapot))
+      );
+    Completes<Response> responseCompletes = handler.execute("idVal1", "idVal2", "idVal3", 1, 2);
+    assertResponsesAreEquals(Response.of(Imateapot), responseCompletes.await());
+  }
+
+  @Test
   public void actionSignature() {
-    final RequestHandler5<String, String, String, Integer, Integer> handler = new RequestHandler5<>(
+    final RequestHandler5<String, String, String, Integer, Integer> handler = createRequestHandler(
       Method.GET,
       "/posts/{postId}/comment/{commentId}/user/{userId}",
       path(0, String.class),
@@ -98,7 +135,7 @@ public class RequestHandler5Test extends RequestHandlerTestBase {
         new Action.MappedParameter("String", "my-comment"),
         new Action.MappedParameter("String", "my-user"))
       );
-    final RequestHandler5<String, String, String, Integer, Integer> handler = new RequestHandler5<>(
+    final RequestHandler5<String, String, String, Integer, Integer> handler = createRequestHandler(
       Method.GET,
       "/posts/{postId}/comment/{commentId}/user/{userId}",
       path(0, String.class),

--- a/src/test/java/io/vlingo/http/resource/ResourceDispatcherGeneratorTest.java
+++ b/src/test/java/io/vlingo/http/resource/ResourceDispatcherGeneratorTest.java
@@ -25,15 +25,16 @@ public class ResourceDispatcherGeneratorTest {
   private Action actionPatchUserName;
   private Action actionGetUser;
   private Action actionGetUsers;
+  private Action actionQueryUserError;
   private List<Action> actions;
   private ConfigurationResource<?> resource;
 
   @Test
   public void testSourceCodeGeneration() throws Exception {
     final ResourceDispatcherGenerator generator = ResourceDispatcherGenerator.forTest(actions, false);
-    
+
     final Result result = generator.generateFor(resource.resourceHandlerClass.getName());
-    
+
     assertNotNull(result);
     assertNotNull(result.sourceFile);
     assertFalse(result.sourceFile.exists());
@@ -45,11 +46,11 @@ public class ResourceDispatcherGeneratorTest {
   @Test
   public void testSourceCodeGenerationWithPersistence() throws Exception {
     final ResourceDispatcherGenerator generator = ResourceDispatcherGenerator.forTest(actions, true);
-    
+
     final Result result = generator.generateFor(resource.resourceHandlerClass.getName());
-    
+
     assertNotNull(result);
-    
+
     assertNotNull(result);
     assertNotNull(result.sourceFile);
     assertTrue(result.sourceFile.exists());
@@ -66,6 +67,7 @@ public class ResourceDispatcherGeneratorTest {
     actionPatchUserName = new Action(2, "PATCH", "/users/{userId}/name", "changeName(String userId, body:io.vlingo.http.sample.user.NameData nameData)", null, true);
     actionGetUser = new Action(3, "GET", "/users/{userId}", "queryUser(String userId)", null, true);
     actionGetUsers = new Action(4, "GET", "/users", "queryUsers()", null, true);
+    actionQueryUserError = new Action(5, "GET", "/users/{userId}/error", "queryUserError(String userId)", null, true);
 
     actions =
             Arrays.asList(
@@ -73,7 +75,8 @@ public class ResourceDispatcherGeneratorTest {
                     actionPatchUserContact,
                     actionPatchUserName,
                     actionGetUser,
-                    actionGetUsers);
+                    actionGetUsers,
+                    actionQueryUserError);
 
     Class<? extends ResourceHandler> resourceHandlerClass = null;
 
@@ -82,7 +85,7 @@ public class ResourceDispatcherGeneratorTest {
     } catch (Exception e) {
       resourceHandlerClass = ConfigurationResource.newResourceHandlerClassFor("io.vlingo.http.sample.user.UserResource");
     }
-    
+
     resource = ConfigurationResource.newResourceFor("user", resourceHandlerClass, 5, actions);
   }
 }

--- a/src/test/java/io/vlingo/http/resource/ResourcesTest.java
+++ b/src/test/java/io/vlingo/http/resource/ResourcesTest.java
@@ -44,7 +44,7 @@ public class ResourcesTest {
       assertNotNull(action.mapper);
     }
     
-    assertEquals(5, countUserActions);
+    assertEquals(6, countUserActions);
     
     final ConfigurationResource<?> profile = (ConfigurationResource<?>) resources.resourceOf("profile");
     

--- a/src/test/java/io/vlingo/http/resource/sse/SseStreamResourceTest.java
+++ b/src/test/java/io/vlingo/http/resource/sse/SseStreamResourceTest.java
@@ -86,7 +86,7 @@ public class SseStreamResourceTest {
 
   @Before
   public void setUp() {
-    world = World.startWithDefaults("test-stream-resource");
+    world = World.startWithDefaults("test-stream-userResource");
     Configuration.define();
     resource = new MockSseStreamResource(world);
   }

--- a/src/test/java/io/vlingo/http/sample/user/UserResource.java
+++ b/src/test/java/io/vlingo/http/sample/user/UserResource.java
@@ -40,7 +40,6 @@ public class UserResource extends ResourceHandler {
 
   public void register(final UserData userData) {
     final Address userAddress = stage().world().addressFactory().uniquePrefixedWith("u-");
-
     final User.State userState =
             User.from(
                     userAddress.idString(),
@@ -78,6 +77,10 @@ public class UserResource extends ResourceHandler {
     } else {
       completes().with(Response.of(Ok, serialized(UserData.from(userState))));
     }
+  }
+
+  public void queryUserError(String userId) {
+    throw new Error("Test exception");
   }
 
   public void queryUsers() {

--- a/src/test/resources/vlingo-http.properties
+++ b/src/test/resources/vlingo-http.properties
@@ -44,7 +44,7 @@ sse.stream.all.pool = 10
 # user resources
 #=====================================
 
-resource.name.user = [register, contact, name, queryUser, queryUsers]
+resource.name.user = [register, contact, name, queryUser, queryUsers, queryUserError]
 
 resource.user.handler = io.vlingo.http.sample.user.UserResource
 resource.user.pool = 10
@@ -70,6 +70,9 @@ action.user.queryUsers.method = GET
 action.user.queryUsers.uri = /users
 action.user.queryUsers.to = queryUsers()
 
+action.user.queryUserError.method = GET
+action.user.queryUserError.uri = /user/{userId}/error
+action.user.queryUserError.to = queryUserError(String userId)
 
 #=====================================
 # profile resources


### PR DESCRIPTION
* add .onError( errorHandler) method to RequestHandler0
* add general try/catch method for executing requests via base RequestHandler class
* add try/catch around ResourceRequestHandlerActor.handleFor
* tests for the above

Items for feedback:
* RequestHandler has no access to log; is there a recommended way to get access to a Logger instance besides plumbing it through the dependencies?
* ErrorHandler is not allowed to handle Throwables, only Exceptions, by design
* The only action taken for Errors (that escape the ErrorHander), is the Response of status 500. Appropriate actions should be considered for Errors that effictively put in doubt the viability of the current VM (OutofMemory or other broad Errors).  
  * Perhaps a Supervisor is needed for this?
