### PR TITLE
Content-type and Accept support for MIME-type content.  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.3 (0.8.4 snapshot)
+
+### Merged pull requests: 
+- Added support for MIME-type sensitive serialization of ResourceHandler results and POST body #35 by [bwehrle](https://github.com/bwehrle)
+
+
 ## 0.8.0
 
 ### Merged pull requests: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.8.3 (0.8.4 snapshot)
 
 ### Merged pull requests: 
-- Added support for MIME-type sensitive serialization of ResourceHandler results and POST body #35 by [bwehrle](https://github.com/bwehrle)
+- Added support for MIME-type sensitive serialization of ResourceHandler results and POST body.  A new functional ResourceHandler type supports returning an ObjectResponse. #37 by [bwehrle](https://github.com/bwehrle)
 
 
 ## 0.8.0

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Reactive, scalable, and resilient HTTP servers and RESTful services running on v
   * Requests that require message body content are auto-mapped to simple Java objects.
 2. To run the Server:
   * [Use Server#startWith() to start the Server actor](https://github.com/vlingo/vlingo-http/blob/master/src/main/java/io/vlingo/http/resource/Server.java)
-  * The light-weight Server is meant to be run inside vlingo/cluster nodes the require RESTful HTTP support.
+  * The light-qualityFactor Server is meant to be run inside vlingo/cluster nodes the require RESTful HTTP support.
 3. See the following for usage examples:
   * [vlingo/http properties file](https://github.com/vlingo/vlingo-http/blob/master/src/test/resources/vlingo-http.properties)
   * [The user resource sample](https://github.com/vlingo/vlingo-http/blob/master/src/main/java/io/vlingo/http/sample/user/UserResource.java)

--- a/src/main/java/io/vlingo/http/media/ContentMediaType.java
+++ b/src/main/java/io/vlingo/http/media/ContentMediaType.java
@@ -1,0 +1,51 @@
+package io.vlingo.http.media;
+
+import io.vlingo.http.resource.MediaTypeNotSupportedException;
+
+import java.util.Map;
+
+public class ContentMediaType extends MediaTypeDescriptor {
+
+  //IANA MIME Type List
+  enum mimeTypes {
+    application,
+    audio,
+    font,
+    image,
+    model,
+    text,
+    video,
+    multipart,
+    message
+  }
+
+  public ContentMediaType(final String mediaType, final String mediaSubType) {
+    super(mediaType, mediaSubType);
+    validate();
+  }
+
+  private void validate() {
+    mimeTypes.valueOf(mimeType);
+    if (mimeSubType.equals("*")) {
+      throw new MediaTypeNotSupportedException("Illegal MIME type:" + toString());
+    }
+  }
+
+  public ContentMediaType(String mediaType, String mediaSubType, Map<String, String> parameters) {
+    super(mediaType, mediaSubType, parameters);
+    validate();
+  }
+
+  public static ContentMediaType Json() {
+    return new ContentMediaType(mimeTypes.application.name(), "json");
+  }
+
+  public static ContentMediaType Xml() {
+    return new ContentMediaType(mimeTypes.application.name(), "xml");
+  }
+
+  public static ContentMediaType parseFromDescriptor(String contentMediaTypeDescriptor) {
+    return MediaTypeParser.parseFrom(contentMediaTypeDescriptor,
+      new MediaTypeDescriptor.Builder<>(ContentMediaType::new));
+  }
+}

--- a/src/main/java/io/vlingo/http/media/MediaTypeDescriptor.java
+++ b/src/main/java/io/vlingo/http/media/MediaTypeDescriptor.java
@@ -1,0 +1,97 @@
+package io.vlingo.http.media;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public abstract class MediaTypeDescriptor {
+
+  static final String PARAMETER_SEPARATOR = ";";
+  static final String MIME_SUBTYPE_SEPARATOR = "/";
+  static final String PARAMETER_ASSIGNMENT = "=";
+
+  protected final String mimeType;
+  protected final String mimeSubType;
+  public final Map<String, String> parameters;
+
+  public MediaTypeDescriptor(String mimeType, String mimeSubType, Map<String, String> parameters) {
+    this.mimeType = mimeType;
+    this.mimeSubType = mimeSubType;
+    this.parameters = new HashMap<>(parameters);
+  }
+
+  public MediaTypeDescriptor(String mimeType, String mimeSubType) {
+    this.mimeType = mimeType;
+    this.mimeSubType = mimeSubType;
+    this.parameters = new HashMap<>();
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(mimeType)
+      .append(MIME_SUBTYPE_SEPARATOR)
+      .append(mimeSubType);
+
+    for (String parameterName : parameters.keySet()) {
+      sb.append(PARAMETER_SEPARATOR)
+        .append(parameterName)
+        .append(PARAMETER_ASSIGNMENT)
+        .append(parameters.get(parameterName));
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MediaTypeDescriptor that = (MediaTypeDescriptor) o;
+    return Objects.equals(mimeType, that.mimeType) &&
+      Objects.equals(mimeSubType, that.mimeSubType) &&
+      Objects.equals(parameters, that.parameters);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(mimeType, mimeSubType, parameters);
+  }
+
+  public static class Builder<T> {
+    protected String mimeType;
+    protected String mimeSubType;
+    protected Map<String, String> parameters;
+    protected final Supplier<T> supplier;
+
+    @FunctionalInterface
+    public interface Supplier<U> {
+      U supply(final String mimeType, final String mimeSubType, final Map<String, String> parameters);
+    }
+
+    public Builder(Supplier<T> supplier) {
+      this.supplier = supplier;
+      parameters = new HashMap<>();
+      mimeType = "";
+      mimeSubType = "";
+    }
+
+    Builder<T> withMimeType(final String mimeType) {
+      this.mimeType = mimeType;
+      return this;
+    }
+
+    Builder<T> withMimeSubType(final String mimeSubType) {
+      this.mimeSubType = mimeSubType;
+      return this;
+    }
+
+    Builder<T> withParameter(final String paramName, final String paramValue) {
+      parameters.put(paramName, paramValue);
+      return this;
+    }
+
+    T build() {
+      return this.supplier.supply(mimeType, mimeSubType, parameters);
+    }
+  }
+}

--- a/src/main/java/io/vlingo/http/media/MediaTypeParser.java
+++ b/src/main/java/io/vlingo/http/media/MediaTypeParser.java
@@ -1,0 +1,41 @@
+package io.vlingo.http.media;
+
+import java.util.Arrays;
+
+import static io.vlingo.http.media.MediaTypeDescriptor.PARAMETER_ASSIGNMENT;
+
+public class MediaTypeParser {
+
+  private static final int MIME_TYPE_AND_SUBTYPE_SIZE = 2;
+  private static final int PARAMETER_VALUE_OFFSET = 1;
+  private static final int PARAMETER_FIELD_OFFSET = 0;
+  private static final int PARAMETER_AND_VALUE_SIZE = 2;
+
+  public static <T extends MediaTypeDescriptor> T parseFrom(final String mediaTypeDescriptor,
+                                                            final MediaTypeDescriptor.Builder<T> builder) {
+    String[] descriptorParts = mediaTypeDescriptor.split(MediaTypeDescriptor.PARAMETER_SEPARATOR);
+    if (descriptorParts.length > 1) {
+      parseAttributes(builder, Arrays.copyOfRange(descriptorParts, 1, descriptorParts.length));
+    }
+
+    String[] mimeParts = descriptorParts[0].split(MediaTypeDescriptor.MIME_SUBTYPE_SEPARATOR);
+    if (mimeParts.length == MIME_TYPE_AND_SUBTYPE_SIZE) {
+      builder.withMimeType(mimeParts[0].trim())
+        .withMimeSubType(mimeParts[1].trim());
+    }
+    return builder.build();
+  }
+
+  private static <T extends MediaTypeDescriptor> void parseAttributes(final MediaTypeDescriptor.Builder<T> builder,
+                                                                      final String[] parameters) {
+      for (String parameter : parameters) {
+        String[] parameterFieldAndValue = parameter.split(PARAMETER_ASSIGNMENT);
+
+        if (parameterFieldAndValue.length == PARAMETER_AND_VALUE_SIZE) {
+          String attributeName = parameterFieldAndValue[PARAMETER_FIELD_OFFSET];
+          String value = parameterFieldAndValue[PARAMETER_VALUE_OFFSET];
+          builder.withParameter(attributeName, value);
+        }
+      }
+  }
+}

--- a/src/main/java/io/vlingo/http/media/ResponseMediaTypeSelector.java
+++ b/src/main/java/io/vlingo/http/media/ResponseMediaTypeSelector.java
@@ -1,0 +1,116 @@
+package io.vlingo.http.media;
+
+import io.vlingo.http.resource.MediaTypeNotSupportedException;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeSet;
+
+public class ResponseMediaTypeSelector {
+
+  private static final String ACCEPT_MEDIA_TYPE_SEPARATOR = ",";
+
+  private final TreeSet<AcceptMediaType> responseMediaTypesByPriority;
+  private final String mediaTypeDescriptors;
+
+  public ResponseMediaTypeSelector(final String mediaTypeDescriptors) {
+    this.responseMediaTypesByPriority = new TreeSet<>();
+    this.mediaTypeDescriptors = mediaTypeDescriptors;
+    parseMediaTypeDescriptors(mediaTypeDescriptors);
+  }
+
+  private void parseMediaTypeDescriptors(final String contentTypeList) {
+    String[] acceptedContentTypeDescriptors = contentTypeList.split(ACCEPT_MEDIA_TYPE_SEPARATOR);
+
+    for (String acceptedContentTypeDescriptor : acceptedContentTypeDescriptors) {
+      AcceptMediaType acceptMediaType = MediaTypeParser.parseFrom(acceptedContentTypeDescriptor.trim(),
+        new MediaTypeDescriptor.Builder<>(AcceptMediaType::new));
+      responseMediaTypesByPriority.add(acceptMediaType);
+    }
+  }
+
+  public ContentMediaType selectType(final ContentMediaType[] supportedContentMediaTypes) {
+    Iterator<AcceptMediaType> iteratorMediaTypeCandidates = responseMediaTypesByPriority.descendingIterator();
+    while (iteratorMediaTypeCandidates.hasNext()) {
+      AcceptMediaType responseMediaType = iteratorMediaTypeCandidates.next();
+      for (ContentMediaType supportedContentMediaType : supportedContentMediaTypes) {
+        if (responseMediaType.isSameOrSuperTypeOf(supportedContentMediaType)) {
+          return supportedContentMediaType;
+        }
+      }
+    }
+    throw new MediaTypeNotSupportedException(mediaTypeDescriptors);
+  }
+
+
+  static class AcceptMediaType extends MediaTypeDescriptor implements Comparable<AcceptMediaType> {
+
+    private static final String MIME_TYPE_WILDCARD = "*";
+    private static final String QUALITY_FACTOR_PARAMETER = "q";
+    private static final float DEFAULT_QUALITY_FACTOR_VALUE = 1.0f;
+
+    private final float qualityFactor;
+
+    AcceptMediaType(final String mimeType, final String mimeSubType, final Map<String, String> parameters) {
+      super(mimeType, mimeSubType, parameters);
+      float qualityFactor = DEFAULT_QUALITY_FACTOR_VALUE;
+
+      if (parameters.containsKey(QUALITY_FACTOR_PARAMETER)) {
+        try {
+          qualityFactor = Float.parseFloat(parameters.get(QUALITY_FACTOR_PARAMETER));
+        } catch (NumberFormatException ignored) { }
+      }
+      this.qualityFactor = qualityFactor;
+    }
+
+    AcceptMediaType(final String mimeType, final String mimeSubType) {
+      super(mimeType, mimeSubType);
+      this.qualityFactor = DEFAULT_QUALITY_FACTOR_VALUE;
+    }
+
+    /**
+     * Compares two AcceptMediaTypes based on specification by:
+     * * quality factor, then
+     * * specificity of media type (specific before wildcards), then
+     * * specificity of sub-media type (specific before wildcards), then
+     * * specificity of parameters (more parameters -> greater specificity)
+     *
+     * @param other AcceptedMediaType against which to compare
+     * @return -1, 0, or 1
+     */
+    @Override
+    public int compareTo(final AcceptMediaType other) {
+      if (this.qualityFactor == other.qualityFactor) {
+        if (isGenericType() && !other.isGenericType()) {
+          return -1;
+        } else if (!isGenericType() && other.isGenericType()) {
+          return 1;
+        } else if (isGenericSubType()) {
+          return (other.isGenericSubType() ? compareParameters(other) : -1);
+        } else {
+          return (other.isGenericSubType() ? 1 : compareParameters(other));
+        }
+      } else {
+        return Float.compare(qualityFactor, other.qualityFactor);
+      }
+    }
+
+    private int compareParameters(final AcceptMediaType other) {
+      return Integer.compare(parameters.size(), other.parameters.size());
+    }
+
+    boolean isSameOrSuperTypeOf(final ContentMediaType contentMediaType) {
+      return
+        (isGenericType() || mimeType.equals(contentMediaType.mimeType))
+          && (isGenericSubType() || mimeSubType.equals(contentMediaType.mimeSubType));
+    }
+
+    private boolean isGenericSubType() {
+      return mimeSubType.equals(MIME_TYPE_WILDCARD);
+    }
+
+    private boolean isGenericType() {
+      return mimeType.equals(MIME_TYPE_WILDCARD);
+    }
+  }
+}

--- a/src/main/java/io/vlingo/http/resource/Action.java
+++ b/src/main/java/io/vlingo/http/resource/Action.java
@@ -39,7 +39,7 @@ public final class Action {
     this.uri = uri;
     this.to = new ToSpec(to);
     this.originalTo = to;
-    this.mapper = mapper == null ? DefaultMapper.instance : mapperFrom(mapper);
+    this.mapper = mapper == null ? DefaultJsonMapper.instance : mapperFrom(mapper);
     this.disallowPathParametersWithSlash = disallowPathParametersWithSlash;
     this.additionalParameters = additionalParameters;
     this.matchable = new Matchable(uri);
@@ -231,7 +231,7 @@ public final class Action {
 
     @Override
     public String toString() {
-      return "MappedParameter[type=" + type + ", value=" + value + "]";
+      return "MappedParameter[mimeType=" + type + ", value=" + value + "]";
     }
   }
 
@@ -317,7 +317,7 @@ public final class Action {
 
     @Override
     public String toString() {
-      return "BodyParameter[type=" + type.getName() + ", name=" + name + "]";
+      return "BodyParameter[mimeType=" + type.getName() + ", name=" + name + "]";
     }
   }
 
@@ -374,7 +374,7 @@ public final class Action {
 
     @Override
     public String toString() {
-      return "MethodParameter[type=" + type + ", name=" + name + "]";
+      return "MethodParameter[mimeType=" + type + ", name=" + name + "]";
     }
   }
 
@@ -646,7 +646,7 @@ public final class Action {
     private String[] typeAndName(final String rawParameter) {
       final int space = rawParameter.lastIndexOf(' ');
       if (space == -1) {
-        throw new IllegalStateException("Parameter type and name must be separated by space: " + rawParameter);
+        throw new IllegalStateException("Parameter mimeType and name must be separated by space: " + rawParameter);
       }
       final String[] type_name = new String[2];
       type_name[0] = rawParameter.substring(0, space).trim();

--- a/src/main/java/io/vlingo/http/resource/ConfigurationResource.java
+++ b/src/main/java/io/vlingo/http/resource/ConfigurationResource.java
@@ -51,7 +51,7 @@ public abstract class ConfigurationResource<T> extends Resource<T> {
 
       Class<ConfigurationResource<?>> resourceClass = null;
       try {
-        // this check is done primarily for testing to prevent duplicate class type in class loader
+        // this check is done primarily for testing to prevent duplicate class mimeType in class loader
         resourceClass = (Class<ConfigurationResource<?>>) Class.forName(targetClassname);
       } catch (Exception e) {
         resourceClass = tryGenerateCompile(resourceHandlerClass, targetClassname, actions);

--- a/src/main/java/io/vlingo/http/resource/Content.java
+++ b/src/main/java/io/vlingo/http/resource/Content.java
@@ -1,0 +1,30 @@
+package io.vlingo.http.resource;
+
+import io.vlingo.http.media.ContentMediaType;
+
+import java.util.Objects;
+
+
+public class Content {
+  public final String data;
+  public final ContentMediaType contentMediaType;
+
+  public Content(String data, ContentMediaType contentMediaType) {
+    this.data = data;
+    this.contentMediaType = contentMediaType;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Content content = (Content) o;
+    return Objects.equals(data, content.data) &&
+      Objects.equals(contentMediaType, content.contentMediaType);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(data, contentMediaType);
+  }
+}

--- a/src/main/java/io/vlingo/http/resource/DefaultErrorHandler.java
+++ b/src/main/java/io/vlingo/http/resource/DefaultErrorHandler.java
@@ -1,0 +1,22 @@
+package io.vlingo.http.resource;
+
+import io.vlingo.common.Completes;
+import io.vlingo.http.Response;
+
+public class DefaultErrorHandler {
+
+  private static ErrorHandler instance = (ex) ->  {
+    if (ex instanceof MediaTypeNotSupportedException) {
+      return Response.of(Response.Status.UnsupportedMediaType);
+    } else if (ex instanceof IllegalArgumentException) {
+      return Response.of(Response.Status.BadRequest);
+    }
+    else {
+      return Response.of(Response.Status.InternalServerError);
+    }
+  };
+
+  public static ErrorHandler instance() {
+    return instance;
+  }
+}

--- a/src/main/java/io/vlingo/http/resource/DefaultJsonMapper.java
+++ b/src/main/java/io/vlingo/http/resource/DefaultJsonMapper.java
@@ -9,8 +9,8 @@ package io.vlingo.http.resource;
 
 import io.vlingo.common.serialization.JsonSerialization;
 
-public class DefaultMapper implements Mapper {
-  public static final Mapper instance = new DefaultMapper();
+public class DefaultJsonMapper implements Mapper {
+  public static final Mapper instance = new DefaultJsonMapper();
   
   @Override
   @SuppressWarnings("unchecked")

--- a/src/main/java/io/vlingo/http/resource/DefaultMediaTypeMapper.java
+++ b/src/main/java/io/vlingo/http/resource/DefaultMediaTypeMapper.java
@@ -1,0 +1,18 @@
+package io.vlingo.http.resource;
+
+import io.vlingo.http.media.ContentMediaType;
+
+public class DefaultMediaTypeMapper  {
+
+  private static MediaTypeMapper instance = buildInstance();
+
+  private static MediaTypeMapper buildInstance() {
+    return new MediaTypeMapper.Builder()
+      .addMapperFor(ContentMediaType.Json(), DefaultJsonMapper.instance)
+      .build();
+  }
+
+  public static MediaTypeMapper instance() {
+    return instance;
+  }
+}

--- a/src/main/java/io/vlingo/http/resource/ErrorHandler.java
+++ b/src/main/java/io/vlingo/http/resource/ErrorHandler.java
@@ -5,9 +5,9 @@ import io.vlingo.http.Response;
 
 public interface ErrorHandler {
 
-  Completes<Response> handle(final Throwable error);
+  Response handle(final Throwable error);
 
   static ErrorHandler handleAllWith(final Response.Status status) {
-    return (error) -> Completes.withSuccess(Response.of(status));
+    return (error) -> Response.of(status);
   }
 }

--- a/src/main/java/io/vlingo/http/resource/Mapper.java
+++ b/src/main/java/io/vlingo/http/resource/Mapper.java
@@ -7,7 +7,10 @@
 
 package io.vlingo.http.resource;
 
+
 public interface Mapper {
   <T> T from(final String data, final Class<T> type);
   <T> String from(final T data);
 }
+
+

--- a/src/main/java/io/vlingo/http/resource/MediaTypeMapper.java
+++ b/src/main/java/io/vlingo/http/resource/MediaTypeMapper.java
@@ -1,0 +1,53 @@
+package io.vlingo.http.resource;
+
+import io.vlingo.http.media.ContentMediaType;
+
+import java.util.*;
+
+public class MediaTypeMapper {
+
+  private final Map<ContentMediaType, Mapper> mappersByContentType;
+
+  public MediaTypeMapper(Map<ContentMediaType, Mapper> mappersByContentType) {
+    this.mappersByContentType = mappersByContentType;
+  }
+
+  public <T> T from(final String data, final ContentMediaType contentMediaType, final Class<T> type) {
+    if (mappersByContentType.containsKey(contentMediaType)) {
+      return mappersByContentType.get(contentMediaType).from(data, type);
+    }
+    throw new MediaTypeNotSupportedException(contentMediaType.toString());
+  }
+
+  public <T> String from(final T data, final ContentMediaType contentMediaType, final Class<T> type) {
+    if (mappersByContentType.containsKey(contentMediaType)) {
+      return  mappersByContentType.get(contentMediaType).from(data);
+    }
+    throw new MediaTypeNotSupportedException(contentMediaType.toString());
+  }
+
+  public ContentMediaType[] mappedMediaTypes() {
+    return this.mappersByContentType.keySet().toArray(new ContentMediaType[0]);
+  }
+
+  public static class Builder {
+    private Map<ContentMediaType, Mapper> mappersByContentType;
+
+    public Builder() {
+      this.mappersByContentType = new HashMap<>();
+    }
+
+    Builder addMapperFor(ContentMediaType contentMediaType, Mapper mapper) {
+      mappersByContentType.computeIfPresent(contentMediaType,
+        (ct, mp) -> {throw new  IllegalArgumentException("Content mimeType already added");});
+      mappersByContentType.put(contentMediaType, mapper);
+      return this;
+    }
+
+    MediaTypeMapper build() {
+      return new MediaTypeMapper(mappersByContentType);
+    }
+  }
+}
+
+

--- a/src/main/java/io/vlingo/http/resource/MediaTypeNotSupportedException.java
+++ b/src/main/java/io/vlingo/http/resource/MediaTypeNotSupportedException.java
@@ -1,0 +1,14 @@
+package io.vlingo.http.resource;
+
+public class MediaTypeNotSupportedException extends RuntimeException {
+  public final String mediaType;
+
+  public MediaTypeNotSupportedException(String mediaType) {
+    this.mediaType = mediaType;
+  }
+
+  @Override
+  public String getMessage() {
+    return "No mapper registered for the following media mimeType: " + mediaType;
+  }
+}

--- a/src/main/java/io/vlingo/http/resource/ObjectResponse.java
+++ b/src/main/java/io/vlingo/http/resource/ObjectResponse.java
@@ -1,0 +1,66 @@
+package io.vlingo.http.resource;
+
+import io.vlingo.http.Body;
+import io.vlingo.http.Header;
+import io.vlingo.http.Header.Headers;
+import io.vlingo.http.media.ContentMediaType;
+import io.vlingo.http.Request;
+import io.vlingo.http.RequestHeader;
+import io.vlingo.http.Response;
+import io.vlingo.http.ResponseHeader;
+import io.vlingo.http.media.ResponseMediaTypeSelector;
+import io.vlingo.http.Version;
+
+public class ObjectResponse<T> {
+
+  private static final ContentMediaType DEFAULT_MEDIA_TYPE = ContentMediaType.Json();
+
+  private final Version version;
+  private final Response.Status status;
+  private final Headers<ResponseHeader> headers;
+  private T entity;
+  private Class<T> clazz;
+
+  private ObjectResponse(final Version version,
+                         final Response.Status status,
+                         final Header.Headers<ResponseHeader> headers,
+                         final T entity,
+                         final Class<T> clazz) {
+    this.version = version;
+    this.status = status;
+    this.headers = headers;
+    this.entity = entity;
+    this.clazz = clazz;
+  }
+
+  public static <T> ObjectResponse<T> of(final Version version,
+                                         final Response.Status status,
+                                         final Header.Headers<ResponseHeader> headers,
+                                         T entity,
+                                         Class<T> classType) {
+    return new ObjectResponse<>(version, status, headers, entity, classType);
+  }
+
+  public static <T> ObjectResponse<T> of(final Response.Status status,
+                                         final Header.Headers<ResponseHeader> headers,
+                                         final T entity,
+                                         final Class<T> classType) {
+    return new ObjectResponse<T>(Version.Http1_1, status, headers, entity, classType);
+  }
+
+  public static <T> ObjectResponse<T> of(final Response.Status status,
+                                         final T entity,
+                                         final Class<T> classType) {
+    return new ObjectResponse<>(Version.Http1_1, status, Header.Headers.empty(), entity, classType);
+  }
+
+  public Response responseFrom(Request request, MediaTypeMapper mapper) {
+    final String acceptedMediaTypes = request.headerValueOr(RequestHeader.Accept, DEFAULT_MEDIA_TYPE.toString());
+    final ResponseMediaTypeSelector responseMediaTypeSelector = new ResponseMediaTypeSelector(acceptedMediaTypes);
+    final ContentMediaType responseContentMediaType = responseMediaTypeSelector.selectType(mapper.mappedMediaTypes());
+    final String bodyContent = mapper.from(entity, responseContentMediaType, clazz);
+    final Body body = Body.from(bodyContent);
+    headers.add(ResponseHeader.of(ResponseHeader.ContentType, responseContentMediaType.toString()));
+    return Response.of(version, status, headers, body);
+  }
+}

--- a/src/main/java/io/vlingo/http/resource/RequestExecutor.java
+++ b/src/main/java/io/vlingo/http/resource/RequestExecutor.java
@@ -1,0 +1,23 @@
+package io.vlingo.http.resource;
+
+import io.vlingo.actors.Logger;
+import io.vlingo.common.Completes;
+import io.vlingo.http.Response;
+
+import java.util.function.Supplier;
+
+abstract class RequestExecutor {
+
+  static Completes<Response> executeRequest(final Supplier<Completes<Response>> executeAction,
+                                            final ErrorHandler errorHandler,
+                                            final Logger logger) {
+
+    try {
+      return executeAction.get()
+        .recoverFrom(ex -> ResourceErrorProcessor.resourceHandlerError(errorHandler, logger, ex));
+    } catch(Exception ex) {
+      return Completes.withFailure(ResourceErrorProcessor.resourceHandlerError(errorHandler, logger, ex));
+    }
+  }
+
+}

--- a/src/main/java/io/vlingo/http/resource/RequestHandler1.java
+++ b/src/main/java/io/vlingo/http/resource/RequestHandler1.java
@@ -17,26 +17,54 @@ import io.vlingo.http.Request;
 import io.vlingo.http.Response;
 
 import java.util.Collections;
+import java.util.function.Supplier;
 
 public class RequestHandler1<T> extends RequestHandler {
-  final ParameterResolver<T> resolver;
-  private Handler1<T> handler;
-  private ErrorHandler errorHandler;
 
-  RequestHandler1(final Method method, final String path, final ParameterResolver<T> resolver,
-                  final ErrorHandler errorHandler) {
-    super(method, path, Collections.singletonList(resolver));
-    this.resolver = resolver;
-    this.errorHandler = errorHandler;
+  @FunctionalInterface
+  public interface Handler1<T> {
+    Completes<Response> execute(T param1);
   }
 
-  Completes<Response> execute(final T param1, final Logger logger) {
-    checkHandlerOrThrowException(handler);
-    return executeRequest(() -> handler.execute(param1), errorHandler, logger);
+  @FunctionalInterface
+  public interface ObjectHandler1<T> {
+    Completes<ObjectResponse<?>> execute(T param1);
+  }
+
+  @FunctionalInterface
+  interface ParamExecutor1<T> {
+    Completes<Response> execute(final Request request,
+                                final T param1,
+                                final MediaTypeMapper mediaTypeMapper,
+                                final ErrorHandler errorHandler,
+                                final Logger logger);
+  }
+
+  final ParameterResolver<T> resolver;
+  private ParamExecutor1<T> executor;
+
+  RequestHandler1(final Method method,
+                  final String path,
+                  final ParameterResolver<T> resolver,
+                  final ErrorHandler errorHandler,
+                  final MediaTypeMapper mediaTypeMapper) {
+    super(method, path, Collections.singletonList(resolver), errorHandler, mediaTypeMapper);
+    this.resolver = resolver;
   }
 
   public RequestHandler1<T> handle(final Handler1<T> handler) {
-    this.handler = handler;
+    executor = ((request, param1, mediaTypeMapper1, errorHandler1, logger1) ->
+      RequestExecutor.executeRequest(() -> handler.execute(param1), errorHandler1, logger1));
+    return this;
+  }
+
+  public RequestHandler1<T> handle(final RequestHandler1.ObjectHandler1<T> handler) {
+    executor = ((request, param1, mediaTypeMapper1, errorHandler1, logger) ->
+      RequestObjectExecutor.executeRequest(request,
+                                           mediaTypeMapper1,
+                                           () -> handler.execute(param1),
+                                           errorHandler1,
+                                           logger));
     return this;
   }
 
@@ -45,34 +73,63 @@ public class RequestHandler1<T> extends RequestHandler {
     return this;
   }
 
+  Completes<Response> execute(final Request request, final T param1, final Logger logger) {
+    final Supplier<Completes<Response>> exec = () ->
+      executor.execute(request, param1, mediaTypeMapper, errorHandler, logger);
+
+    return runParamExecutor(executor, () -> RequestExecutor.executeRequest(exec, errorHandler, logger));
+  }
+
   @Override
   Completes<Response> execute(final Request request,
                               final Action.MappedParameters mappedParameters,
                               final Logger logger) {
-    return execute(resolver.apply(request, mappedParameters), logger);
-  }
-
-  @FunctionalInterface
-  public interface Handler1<T> {
-    Completes<Response> execute(T param1);
+    return execute(request, resolver.apply(request, mappedParameters), logger);
   }
 
   // region FluentAPI
 
   public <R> RequestHandler2<T, R> param(final Class<R> paramClass) {
-    return new RequestHandler2<>(method, path, resolver, ParameterResolver.path(1, paramClass), errorHandler);
+    return new RequestHandler2<>(method, path, resolver, ParameterResolver.path(1, paramClass), errorHandler,
+                                 mediaTypeMapper);
   }
 
   public <R> RequestHandler2<T, R> body(final Class<R> bodyClass) {
-    return new RequestHandler2<>(method, path, resolver, ParameterResolver.body(bodyClass), errorHandler);
+    return new RequestHandler2<>(method, path, resolver, ParameterResolver.body(bodyClass, mediaTypeMapper),
+                                 errorHandler, mediaTypeMapper);
   }
 
+  /**
+   * Specify the class that represents the body of the request for all requests using the specified mapper for all
+   * MIME types regardless of the Content-Type header.
+   *
+   * @deprecated Deprecated in favor of using the ContentMediaType method, which handles media types appropriately.
+   * {@link RequestHandler1#body(java.lang.Class, io.vlingo.http.resource.MediaTypeMapper)} instead, or via
+   * {@link RequestHandler1#body(java.lang.Class)}
+   */
+  @Deprecated
   public <R> RequestHandler2<T, R> body(final Class<R> bodyClass, final Class<? extends Mapper> mapperClass) {
     return body(bodyClass, mapperFrom(mapperClass));
   }
 
+  /**
+   * Specify the class that represents the body of the request for all requests using the specified mapper for all
+   * MIME types regardless of the Content-Type header.
+   *
+   * @deprecated Deprecated in favor of using the ContentMediaType method, which handles media types appropriately.
+   * {@link RequestHandler1#body(java.lang.Class, io.vlingo.http.resource.MediaTypeMapper)}instead, or via
+   * {@link RequestHandler1#body(java.lang.Class)}
+   */
+  @Deprecated
   public <R> RequestHandler2<T, R> body(final Class<R> bodyClass, final Mapper mapper) {
-    return new RequestHandler2<>(method, path, resolver, ParameterResolver.body(bodyClass, mapper), errorHandler);
+    return new RequestHandler2<>(method, path, resolver, ParameterResolver.body(bodyClass, mapper), errorHandler,
+                                 mediaTypeMapper);
+  }
+
+  public <R> RequestHandler2<T, R> body(final Class<R> bodyClass, final MediaTypeMapper mediaTypeMapper) {
+    this.mediaTypeMapper = mediaTypeMapper;
+    return new RequestHandler2<>(method, path, resolver, ParameterResolver.body(bodyClass, mediaTypeMapper),
+                                 errorHandler, mediaTypeMapper);
   }
 
   public RequestHandler2<T, String> query(final String name) {
@@ -84,11 +141,12 @@ public class RequestHandler1<T> extends RequestHandler {
   }
 
   public <R> RequestHandler2<T, R> query(final String name, final Class<R> queryClass, final R defaultValue) {
-    return new RequestHandler2<>(method, path, resolver, ParameterResolver.query(name, queryClass, defaultValue), errorHandler);
+    return new RequestHandler2<>(method, path, resolver, ParameterResolver.query(name, queryClass, defaultValue),
+                                 errorHandler, mediaTypeMapper);
   }
 
   public RequestHandler2<T, Header> header(final String name) {
-    return new RequestHandler2<>(method, path, resolver, ParameterResolver.header(name), errorHandler);
+    return new RequestHandler2<>(method, path, resolver, ParameterResolver.header(name), errorHandler, mediaTypeMapper);
   }
 
   // endregion

--- a/src/main/java/io/vlingo/http/resource/RequestHandler2.java
+++ b/src/main/java/io/vlingo/http/resource/RequestHandler2.java
@@ -17,31 +17,64 @@ import io.vlingo.http.Request;
 import io.vlingo.http.Response;
 
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 public class RequestHandler2<T, R> extends RequestHandler {
   final ParameterResolver<T> resolverParam1;
   final ParameterResolver<R> resolverParam2;
-  private Handler2<T, R> handler;
-  private ErrorHandler errorHandler;
+  private ParamExecutor2<T,R> executor;
+
+  @FunctionalInterface
+  public interface Handler2<T, R> {
+    Completes<Response> execute(T param1, R param2);
+  }
+
+  @FunctionalInterface
+  public interface ObjectHandler2<T, R> {
+    Completes<ObjectResponse<?>> execute(T param1, R param2);
+  }
+
+  @FunctionalInterface
+  interface ParamExecutor2<T, R> {
+    Completes<Response> execute(final Request request,
+                                final T param1,
+                                final R param2,
+                                final MediaTypeMapper mediaTypeMapper,
+                                final ErrorHandler errorHandler,
+                                final Logger logger);
+  }
 
   RequestHandler2(final Method method,
                   final String path,
                   final ParameterResolver<T> resolverParam1,
                   final ParameterResolver<R> resolverParam2,
-                  final ErrorHandler errorHandler) {
-    super(method, path, Arrays.asList(resolverParam1, resolverParam2));
+                  final ErrorHandler errorHandler,
+                  final MediaTypeMapper mediaTypeMapper) {
+    super(method, path, Arrays.asList(resolverParam1, resolverParam2), errorHandler, mediaTypeMapper);
     this.resolverParam1 = resolverParam1;
     this.resolverParam2 = resolverParam2;
-    this.errorHandler = errorHandler;
   }
 
-  Completes<Response> execute(final T param1, final R param2, final Logger logger) {
-    checkHandlerOrThrowException(handler);
-    return executeRequest(() -> handler.execute(param1, param2), errorHandler, logger);
+  Completes<Response> execute(final Request request, final T param1, final R param2, final Logger logger) {
+    final Supplier<Completes<Response>> exec = () ->
+      executor.execute(request, param1, param2, mediaTypeMapper, errorHandler, logger);
+
+    return runParamExecutor(executor, () -> RequestExecutor.executeRequest(exec, errorHandler, logger));
   }
 
   public RequestHandler2<T, R> handle(final Handler2<T, R> handler) {
-    this.handler = handler;
+    executor = ((request, param1, param2, mediaTypeMapper1, errorHandler1, logger1) ->
+      RequestExecutor.executeRequest(() -> handler.execute(param1, param2), errorHandler1, logger1));
+    return this;
+  }
+
+  public RequestHandler2<T, R> handle(final ObjectHandler2<T, R> handler) {
+    executor = ((request, param1, param2, mediaTypeMapper1, errorHandler1, logger) ->
+      RequestObjectExecutor.executeRequest(request,
+        mediaTypeMapper1,
+        () -> handler.execute(param1, param2),
+        errorHandler1,
+        logger));
     return this;
   }
 
@@ -56,30 +89,49 @@ public class RequestHandler2<T, R> extends RequestHandler {
                                      final Logger logger) {
     final T param1 = resolverParam1.apply(request, mappedParameters);
     final R param2 = resolverParam2.apply(request, mappedParameters);
-    return execute(param1, param2, logger);
-  }
-
-  @FunctionalInterface
-  public interface Handler2<T, R> {
-    Completes<Response> execute(T param1, R param2);
+    return execute(request, param1, param2, logger);
   }
 
   // region FluentAPI
   public <U> RequestHandler3<T, R, U> param(final Class<U> paramClass) {
-    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2, ParameterResolver.path(2, paramClass), errorHandler);
+    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2, ParameterResolver.path(2, paramClass), errorHandler, mediaTypeMapper);
   }
 
   public <U> RequestHandler3<T, R, U> body(final Class<U> bodyClass) {
-    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2, ParameterResolver.body(bodyClass), errorHandler);
+    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2, ParameterResolver.body(bodyClass, mediaTypeMapper), errorHandler, mediaTypeMapper);
   }
 
+  /**
+   * Specify the class that represents the body of the request for all requests using the specified mapper for all
+   * MIME types regardless of the Content-Type header.
+   *
+   * @deprecated Deprecated in favor of using the ContentMediaType method, which handles media types appropriately.
+   * {@link RequestHandler2#body(java.lang.Class, io.vlingo.http.resource.MediaTypeMapper)} instead, or via
+   * {@link RequestHandler2#body(java.lang.Class)}
+   */
   public <U> RequestHandler3<T, R, U> body(final Class<U> bodyClass, final Class<? extends Mapper> mapperClass) {
     return body(bodyClass, mapperFrom(mapperClass));
   }
 
+  /**
+   * Specify the class that represents the body of the request for all requests using the specified mapper for all
+   * MIME types regardless of the Content-Type header.
+   *
+   * @deprecated Deprecated in favor of using the ContentMediaType method, which handles media types appropriately.
+   * {@link RequestHandler2#body(java.lang.Class, io.vlingo.http.resource.MediaTypeMapper)} instead, or via
+   * {@link RequestHandler2#body(java.lang.Class)}
+   */
   public <U> RequestHandler3<T, R, U> body(final Class<U> bodyClass, final Mapper mapper) {
     return new RequestHandler3<>(method, path, resolverParam1, resolverParam2,
-      ParameterResolver.body(bodyClass, mapper), errorHandler);
+      ParameterResolver.body(bodyClass, mapper),
+      errorHandler,
+      mediaTypeMapper);
+  }
+
+  public <U> RequestHandler3<T, R, U> body(final Class<U> bodyClass, final MediaTypeMapper mediaTypeMapper) {
+    this.mediaTypeMapper = mediaTypeMapper;
+    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2,
+      ParameterResolver.body(bodyClass, mediaTypeMapper), errorHandler, mediaTypeMapper);
   }
 
   public RequestHandler3<T, R, String> query(final String name) {
@@ -87,11 +139,52 @@ public class RequestHandler2<T, R> extends RequestHandler {
   }
 
   public <U> RequestHandler3<T, R, U> query(final String name, final Class<U> queryClass) {
-    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2, ParameterResolver.query(name, queryClass), errorHandler);
+    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2, ParameterResolver.query(name, queryClass), errorHandler, mediaTypeMapper);
   }
 
   public RequestHandler3<T, R, Header> header(final String name) {
-    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2, ParameterResolver.header(name), errorHandler);
+    return new RequestHandler3<>(method, path, resolverParam1, resolverParam2, ParameterResolver.header(name), errorHandler, mediaTypeMapper);
   }
   // endregion
+
+
+  static class RequestExecutor2<T, R> extends RequestExecutor implements ParamExecutor2<T,R> {
+    private final Handler2<T,R> handler;
+
+    private RequestExecutor2(Handler2<T,R> handler) { this.handler = handler; }
+
+    public Completes<Response> execute(final Request request,
+                                       final T param1,
+                                       final R param2,
+                                       final MediaTypeMapper mediaTypeMapper,
+                                       final ErrorHandler errorHandler,
+                                       final Logger logger) {
+      return executeRequest(() -> handler.execute(param1, param2), errorHandler, logger);
+    }
+
+    static <T,R> RequestExecutor2<T,R> from(final Handler2<T,R> handler) {
+      return new RequestExecutor2<>(handler);}
+  }
+
+  static class RequestObjectExecutor2<T,R> extends RequestObjectExecutor implements ParamExecutor2<T,R> {
+    private final ObjectHandler2<T,R> handler;
+    private RequestObjectExecutor2(ObjectHandler2<T,R> handler) { this.handler = handler;}
+
+    public Completes<Response> execute(final Request request,
+                                       final T param1,
+                                       final R param2,
+                                       final MediaTypeMapper mediaTypeMapper,
+                                       final ErrorHandler errorHandler,
+                                       final Logger logger) {
+      return executeRequest(request,
+                            mediaTypeMapper,
+                            () -> handler.execute(param1, param2),
+                            errorHandler,
+                            logger);
+    }
+
+    static <T,R> RequestObjectExecutor2<T,R> from(final ObjectHandler2<T,R> handler) {
+      return new RequestObjectExecutor2<>(handler);}
+  }
+
 }

--- a/src/main/java/io/vlingo/http/resource/RequestHandler3.java
+++ b/src/main/java/io/vlingo/http/resource/RequestHandler3.java
@@ -8,34 +8,68 @@ import io.vlingo.http.Request;
 import io.vlingo.http.Response;
 
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 public class RequestHandler3<T, R, U> extends RequestHandler {
   final ParameterResolver<T> resolverParam1;
   final ParameterResolver<R> resolverParam2;
   final ParameterResolver<U> resolverParam3;
-  private Handler3<T, R, U> handler;
-  private ErrorHandler errorHandler;
+  private ParamExecutor3<T,R,U> executor;
+
+  @FunctionalInterface
+  public interface Handler3<T, R, U> {
+    Completes<Response> execute(T param1, R param2, U param3);
+  }
+
+  @FunctionalInterface
+  public interface ObjectHandler3<T, R, U> {
+    Completes<ObjectResponse<?>> execute(T param1, R param2, U param3);
+  }
+
+  @FunctionalInterface
+  interface ParamExecutor3<T, R, U> {
+    Completes<Response> execute(final Request request,
+                                final T param1,
+                                final R param2,
+                                final U param3,
+                                final MediaTypeMapper mediaTypeMapper,
+                                final ErrorHandler errorHandler,
+                                final Logger logger);
+  }
 
   RequestHandler3(final Method method,
                   final String path,
                   final ParameterResolver<T> resolverParam1,
                   final ParameterResolver<R> resolverParam2,
                   final ParameterResolver<U> resolverParam3,
-                  final ErrorHandler errorHandler) {
-    super(method, path, Arrays.asList(resolverParam1, resolverParam2, resolverParam3));
+                  final ErrorHandler errorHandler,
+                  final MediaTypeMapper mediaTypeMapper) {
+    super(method, path, Arrays.asList(resolverParam1, resolverParam2, resolverParam3), errorHandler, mediaTypeMapper);
     this.resolverParam1 = resolverParam1;
     this.resolverParam2 = resolverParam2;
     this.resolverParam3 = resolverParam3;
-    this.errorHandler = errorHandler;
   }
 
-  Completes<Response> execute(final T param1, final R param2, final U param3, final Logger logger) {
-    checkHandlerOrThrowException(handler);
-    return executeRequest(() -> handler.execute(param1, param2, param3), errorHandler, logger);
+  Completes<Response> execute(final Request request, final T param1, final R param2, final U param3, final Logger logger) {
+    final Supplier<Completes<Response>> exec = () ->
+      executor.execute(request, param1, param2, param3, mediaTypeMapper, errorHandler, logger);
+
+    return runParamExecutor(executor, () -> RequestExecutor.executeRequest(exec, errorHandler, logger));
   }
 
   public RequestHandler3<T, R, U> handle(final Handler3<T, R, U> handler) {
-    this.handler = handler;
+    executor = ((request, param1, param2, param3, mediaTypeMapper1, errorHandler1, logger1) ->
+      RequestExecutor.executeRequest(() -> handler.execute(param1, param2, param3), errorHandler1, logger1));
+    return this;
+  }
+
+  public RequestHandler3<T, R, U> handle(final ObjectHandler3<T, R, U> handler) {
+    executor = ((request, param1, param2, param3, mediaTypeMapper1, errorHandler1, logger) ->
+      RequestObjectExecutor.executeRequest(request,
+        mediaTypeMapper1,
+        () -> handler.execute(param1, param2, param3),
+        errorHandler1,
+        logger));
     return this;
   }
 
@@ -51,35 +85,60 @@ public class RequestHandler3<T, R, U> extends RequestHandler {
     final T param1 = resolverParam1.apply(request, mappedParameters);
     final R param2 = resolverParam2.apply(request, mappedParameters);
     final U param3 = resolverParam3.apply(request, mappedParameters);
-    return execute(param1, param2, param3, logger);
-  }
+    final Supplier<Completes<Response>> exec = () ->
+      executor.execute(request, param1, param2, param3, mediaTypeMapper, errorHandler, logger);
 
-  @FunctionalInterface
-  public interface Handler3<T, R, U> {
-    Completes<Response> execute(T param1, R param2, U param3);
+    return runParamExecutor(executor, () -> RequestExecutor.executeRequest(exec, errorHandler, logger));
   }
 
   // region FluentAPI
   public <I> RequestHandler4<T, R, U, I> param(final Class<I> paramClass) {
     return new RequestHandler4<>(method, path, resolverParam1, resolverParam2, resolverParam3,
       ParameterResolver.path(3, paramClass),
-      errorHandler);
+      errorHandler,
+      mediaTypeMapper);
   }
 
   public <I> RequestHandler4<T, R, U, I> body(final Class<I> bodyClass) {
     return new RequestHandler4<>(method, path, resolverParam1, resolverParam2, resolverParam3,
-      ParameterResolver.body(bodyClass),
-      errorHandler);
+      ParameterResolver.body(bodyClass, mediaTypeMapper),
+      errorHandler,
+      mediaTypeMapper);
   }
 
+  /**
+   * Specify the class that represents the body of the request for all requests using the specified mapper for all
+   * MIME types regardless of the Content-Type header.
+   *
+   * @deprecated Deprecated in favor of using the ContentMediaType method, which handles media types appropriately.
+   * {@link RequestHandler3#body(java.lang.Class, io.vlingo.http.resource.MediaTypeMapper)} instead, or via
+   * {@link RequestHandler3#body(java.lang.Class)}
+   */
   public <I> RequestHandler4<T, R, U, I> body(final Class<I> bodyClass, final Class<? extends Mapper> mapperClass) {
     return body(bodyClass, mapperFrom(mapperClass));
   }
 
+  /**
+   * Specify the class that represents the body of the request for all requests using the specified mapper for all
+   * MIME types regardless of the Content-Type header.
+   *
+   * @deprecated Deprecated in favor of using the ContentMediaType method, which handles media types appropriately.
+   * {@link RequestHandler3#body(java.lang.Class, io.vlingo.http.resource.MediaTypeMapper)} instead, or via
+   * {@link RequestHandler3#body(java.lang.Class)}
+   */
   public <I> RequestHandler4<T, R, U, I> body(final Class<I> bodyClass, final Mapper mapper) {
     return new RequestHandler4<>(method, path, resolverParam1, resolverParam2, resolverParam3,
       ParameterResolver.body(bodyClass, mapper),
-      errorHandler);
+      errorHandler,
+      mediaTypeMapper);
+  }
+
+  public <I> RequestHandler4<T, R, U, I> body(final Class<I> bodyClass, final MediaTypeMapper mediaTypeMapper) {
+    this.mediaTypeMapper = mediaTypeMapper;
+    return new RequestHandler4<>(method, path, resolverParam1, resolverParam2, resolverParam3,
+      ParameterResolver.body(bodyClass, mediaTypeMapper),
+      errorHandler,
+      mediaTypeMapper);
   }
 
   public RequestHandler4<T, R, U, String> query(final String name) {
@@ -89,13 +148,15 @@ public class RequestHandler3<T, R, U> extends RequestHandler {
   public <I> RequestHandler4<T, R, U, I> query(final String name, final Class<I> queryClass) {
     return new RequestHandler4<>(method, path, resolverParam1, resolverParam2, resolverParam3,
       ParameterResolver.query(name, queryClass),
-      errorHandler);
+      errorHandler,
+      mediaTypeMapper);
   }
 
   public RequestHandler4<T, R, U, Header> header(final String name) {
     return new RequestHandler4<>(method, path, resolverParam1, resolverParam2, resolverParam3,
       ParameterResolver.header(name),
-      errorHandler);
+      errorHandler,
+      mediaTypeMapper);
   }
   // endregion
 }

--- a/src/main/java/io/vlingo/http/resource/RequestHandler4.java
+++ b/src/main/java/io/vlingo/http/resource/RequestHandler4.java
@@ -8,14 +8,36 @@ import io.vlingo.http.Request;
 import io.vlingo.http.Response;
 
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 public class RequestHandler4<T, R, U, I> extends RequestHandler {
   final ParameterResolver<T> resolverParam1;
   final ParameterResolver<R> resolverParam2;
   final ParameterResolver<U> resolverParam3;
   final ParameterResolver<I> resolverParam4;
-  private Handler4<T, R, U, I> handler;
-  private ErrorHandler errorHandler;
+  private ParamExecutor4<T,R,U,I> executor;
+
+
+  @FunctionalInterface
+  public interface Handler4<T, R, U, I> {
+    Completes<Response> execute(T param1, R param2, U param3, I param4);
+  }
+
+  @FunctionalInterface
+  public interface ObjectHandler4<T, R, U, I> {
+    Completes<ObjectResponse<?>> execute(T param1, R param2, U param3, I param4);
+  }
+
+  interface ParamExecutor4<T, R, U, I> {
+    Completes<Response> execute(final Request request,
+                                final T param1,
+                                final R param2,
+                                final U param3,
+                                final I param4,
+                                final MediaTypeMapper mediaTypeMapper,
+                                final ErrorHandler errorHandler,
+                                final Logger logger);
+  }
 
   RequestHandler4(final Method method,
                   final String path,
@@ -23,22 +45,40 @@ public class RequestHandler4<T, R, U, I> extends RequestHandler {
                   final ParameterResolver<R> resolverParam2,
                   final ParameterResolver<U> resolverParam3,
                   final ParameterResolver<I> resolverParam4,
-                  final ErrorHandler errorHandler) {
-    super(method, path, Arrays.asList(resolverParam1, resolverParam2, resolverParam3, resolverParam4));
+                  final ErrorHandler errorHandler,
+                  final MediaTypeMapper mediaTypeMapper) {
+    super(method, path, Arrays.asList(resolverParam1, resolverParam2, resolverParam3, resolverParam4), errorHandler, mediaTypeMapper);
     this.resolverParam1 = resolverParam1;
     this.resolverParam2 = resolverParam2;
     this.resolverParam3 = resolverParam3;
     this.resolverParam4 = resolverParam4;
-    this.errorHandler = errorHandler;
   }
 
-  Completes<Response> execute(final T param1, final R param2, final U param3, final I param4, final Logger logger) {
-    checkHandlerOrThrowException(handler);
-    return executeRequest(() -> handler.execute(param1, param2, param3, param4), errorHandler, logger);
+  Completes<Response> execute(final Request request,
+                              final T param1,
+                              final R param2,
+                              final U param3,
+                              final I param4,
+                              final Logger logger) {
+    final Supplier<Completes<Response>> exec = () ->
+      executor.execute(request, param1, param2, param3, param4, mediaTypeMapper, errorHandler, logger);
+
+    return runParamExecutor(executor, () -> RequestExecutor.executeRequest(exec, errorHandler, logger));
   }
 
   public RequestHandler4<T, R, U, I> handle(final Handler4<T, R, U, I> handler) {
-    this.handler = handler;
+    executor = ((request, param1, param2, param3, param4, mediaTypeMapper1, errorHandler1, logger1) ->
+      RequestExecutor.executeRequest(() -> handler.execute(param1, param2, param3, param4), errorHandler1, logger1));
+    return this;
+  }
+
+  public RequestHandler4<T, R, U, I> handle(final ObjectHandler4<T, R, U, I> handler) {
+    executor = ((request, param1, param2, param3, param4, mediaTypeMapper1, errorHandler1, logger) ->
+      RequestObjectExecutor.executeRequest(request,
+        mediaTypeMapper1,
+        () -> handler.execute(param1, param2, param3, param4),
+        errorHandler1,
+        logger));
     return this;
   }
 
@@ -55,35 +95,59 @@ public class RequestHandler4<T, R, U, I> extends RequestHandler {
     final R param2 = resolverParam2.apply(request, mappedParameters);
     final U param3 = resolverParam3.apply(request, mappedParameters);
     final I param4 = resolverParam4.apply(request, mappedParameters);
-    return execute(param1, param2, param3, param4, logger);
+    final Supplier<Completes<Response>> exec = () ->
+      executor.execute(request, param1, param2, param3, param4, mediaTypeMapper, errorHandler, logger);
+    return runParamExecutor(executor, () -> RequestExecutor.executeRequest(exec, errorHandler, logger));
   }
 
-  @FunctionalInterface
-  public interface Handler4<T, R, U, I> {
-    Completes<Response> execute(T param1, R param2, U param3, I param4);
-  }
 
   // region FluentAPI
   public <J> RequestHandler5<T, R, U, I, J> param(final Class<J> paramClass) {
     return new RequestHandler5<>(method, path, resolverParam1, resolverParam2, resolverParam3, resolverParam4,
       ParameterResolver.path(4, paramClass),
-      errorHandler);
+      errorHandler,
+      mediaTypeMapper);
   }
 
   public <J> RequestHandler5<T, R, U, I, J> body(final Class<J> bodyClass) {
     return new RequestHandler5<>(method, path, resolverParam1, resolverParam2, resolverParam3, resolverParam4,
-      ParameterResolver.body(bodyClass),
-      errorHandler);
+      ParameterResolver.body(bodyClass, mediaTypeMapper),
+      errorHandler,
+      mediaTypeMapper);
   }
 
+  /**
+   * Specify the class that represents the body of the request for all requests using the specified mapper for all
+   * MIME types regardless of the Content-Type header.
+   *
+   * @deprecated Deprecated in favor of using the ContentMediaType method, which handles media types appropriately.
+   * {@link RequestHandler4#body(java.lang.Class, io.vlingo.http.resource.MediaTypeMapper)} instead, or via
+   * {@link RequestHandler4#body(java.lang.Class)}
+   */
   public <J> RequestHandler5<T, R, U, I, J> body(final Class<J> bodyClass, final Class<? extends Mapper> mapperClass) {
     return body(bodyClass, mapperFrom(mapperClass));
   }
 
+  /**
+   * Specify the class that represents the body of the request for all requests using the specified mapper for all
+   * MIME types regardless of the Content-Type header.
+   *
+   * @deprecated Deprecated in favor of using the ContentMediaType method, which handles media types appropriately.
+   * {@link RequestHandler4#body(java.lang.Class, io.vlingo.http.resource.MediaTypeMapper)} instead, or via
+   * {@link RequestHandler4#body(java.lang.Class)}
+   */
   public <J> RequestHandler5<T, R, U, I, J> body(final Class<J> bodyClass, final Mapper mapper) {
     return new RequestHandler5<>(method, path, resolverParam1, resolverParam2, resolverParam3, resolverParam4,
       ParameterResolver.body(bodyClass, mapper),
-      errorHandler);
+      errorHandler,
+      mediaTypeMapper);
+  }
+
+  public <J> RequestHandler5<T, R, U, I, J> body(final Class<J> bodyClass, final MediaTypeMapper mediaTypeMapper) {
+    return new RequestHandler5<>(method, path, resolverParam1, resolverParam2, resolverParam3, resolverParam4,
+      ParameterResolver.body(bodyClass, mediaTypeMapper),
+      errorHandler,
+      mediaTypeMapper);
   }
 
   public RequestHandler5<T, R, U, I, String> query(final String name) {
@@ -93,13 +157,15 @@ public class RequestHandler4<T, R, U, I> extends RequestHandler {
   public <J> RequestHandler5<T, R, U, I, J> query(final String name, final Class<J> queryClass) {
     return new RequestHandler5<>(method, path, resolverParam1, resolverParam2, resolverParam3, resolverParam4,
       ParameterResolver.query(name, queryClass),
-      errorHandler);
+      errorHandler,
+      mediaTypeMapper);
   }
 
   public RequestHandler5<T, R, U, I, Header> header(final String name) {
     return new RequestHandler5<>(method, path, resolverParam1, resolverParam2, resolverParam3, resolverParam4,
       ParameterResolver.header(name),
-      errorHandler);
+      errorHandler,
+      mediaTypeMapper);
   }
   // endregion
 }

--- a/src/main/java/io/vlingo/http/resource/RequestHandler5.java
+++ b/src/main/java/io/vlingo/http/resource/RequestHandler5.java
@@ -7,6 +7,7 @@ import io.vlingo.http.Request;
 import io.vlingo.http.Response;
 
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 public class RequestHandler5<T, R, U, I, J> extends RequestHandler {
   final ParameterResolver<T> resolverParam1;
@@ -14,8 +15,30 @@ public class RequestHandler5<T, R, U, I, J> extends RequestHandler {
   final ParameterResolver<U> resolverParam3;
   final ParameterResolver<I> resolverParam4;
   final ParameterResolver<J> resolverParam5;
-  private Handler5<T, R, U, I, J> handler;
-  private ErrorHandler errorHandler;
+  private ParamExecutor5<T,R,U,I,J> executor;
+
+  @FunctionalInterface
+  public interface Handler5<T, R, U, I, J> {
+    Completes<Response> execute(T param1, R param2, U param3, I param4, J param5);
+  }
+
+  @FunctionalInterface
+  public interface ObjectHandler5<T, R, U, I, J> {
+    Completes<ObjectResponse<?>> execute(T param1, R param2, U param3, I param4, J param5);
+  }
+
+  @FunctionalInterface
+  interface ParamExecutor5<T, R, U, I, J> {
+    Completes<Response> execute(final Request request,
+                                final T param1,
+                                final R param2,
+                                final U param3,
+                                final I param4,
+                                final J param5,
+                                final MediaTypeMapper mediaTypeMapper,
+                                final ErrorHandler errorHandler,
+                                final Logger logger);
+  }
 
   RequestHandler5(final Method method,
                   final String path,
@@ -24,24 +47,42 @@ public class RequestHandler5<T, R, U, I, J> extends RequestHandler {
                   final ParameterResolver<U> resolverParam3,
                   final ParameterResolver<I> resolverParam4,
                   final ParameterResolver<J> resolverParam5,
-                  final ErrorHandler errorHandler) {
-    super(method, path, Arrays.asList(resolverParam1, resolverParam2, resolverParam3, resolverParam4, resolverParam5));
+                  final ErrorHandler errorHandler,
+                  final MediaTypeMapper mediaTypeMapper) {
+    super(method, path, Arrays.asList(resolverParam1, resolverParam2, resolverParam3, resolverParam4, resolverParam5), errorHandler, mediaTypeMapper);
     this.resolverParam1 = resolverParam1;
     this.resolverParam2 = resolverParam2;
     this.resolverParam3 = resolverParam3;
     this.resolverParam4 = resolverParam4;
     this.resolverParam5 = resolverParam5;
-    this.errorHandler = errorHandler;
   }
 
-  Completes<Response> execute(final T param1, final R param2, final U param3, final I param4, final J param5,
+  Completes<Response> execute(final Request request,
+                              final T param1,
+                              final R param2,
+                              final U param3,
+                              final I param4,
+                              final J param5,
                               final Logger logger) {
-    checkHandlerOrThrowException(handler);
-    return executeRequest(() -> handler.execute(param1, param2, param3, param4, param5), errorHandler, logger);
+    final Supplier<Completes<Response>> exec = () ->
+      executor.execute(request, param1, param2, param3, param4, param5, mediaTypeMapper, errorHandler, logger);
+
+    return runParamExecutor(executor, () -> RequestExecutor.executeRequest(exec, errorHandler, logger));
+  }
+  
+  public RequestHandler5<T, R, U, I, J> handle(final Handler5<T, R, U, I, J> handler) {
+    executor = ((request, param1, param2, param3, param4, param5, mediaTypeMapper1, errorHandler1, logger1) ->
+      RequestExecutor.executeRequest(() -> handler.execute(param1, param2, param3, param4, param5), errorHandler1, logger1));
+    return this;
   }
 
-  public RequestHandler5<T, R, U, I, J> handle(final Handler5<T, R, U, I, J> handler) {
-    this.handler = handler;
+  public RequestHandler5<T, R, U, I, J> handle(final ObjectHandler5<T, R, U, I, J> handler) {
+    executor = (request, param1, param2, param3, param4, param5, mediaTypeMapper1, errorHandler1, logger) ->
+      RequestObjectExecutor.executeRequest(request,
+        mediaTypeMapper1,
+        () -> handler.execute(param1, param2, param3, param4, param5),
+        errorHandler1,
+        logger);
     return this;
   }
 
@@ -59,11 +100,9 @@ public class RequestHandler5<T, R, U, I, J> extends RequestHandler {
     final U param3 = resolverParam3.apply(request, mappedParameters);
     final I param4 = resolverParam4.apply(request, mappedParameters);
     final J param5 = resolverParam5.apply(request, mappedParameters);
-    return execute(param1, param2, param3, param4, param5, logger);
+    final Supplier<Completes<Response>> exec = () ->
+      executor.execute(request, param1, param2, param3, param4, param5, mediaTypeMapper, errorHandler, logger);
+    return runParamExecutor(executor, () -> RequestExecutor.executeRequest(exec, errorHandler, logger));
   }
 
-  @FunctionalInterface
-  public interface Handler5<T, R, U, I, J> {
-    Completes<Response> execute(T param1, R param2, U param3, I param4, J param5);
-  }
 }

--- a/src/main/java/io/vlingo/http/resource/RequestObjectExecutor.java
+++ b/src/main/java/io/vlingo/http/resource/RequestObjectExecutor.java
@@ -1,0 +1,39 @@
+package io.vlingo.http.resource;
+
+import io.vlingo.actors.Logger;
+import io.vlingo.common.Completes;
+import io.vlingo.common.Success;
+import io.vlingo.http.Request;
+import io.vlingo.http.Response;
+
+import java.util.function.Supplier;
+
+abstract class RequestObjectExecutor {
+
+  static Completes<Response> executeRequest(final Request request,
+                                            final MediaTypeMapper mediaTypeMapper,
+                                            final Supplier<Completes<ObjectResponse<?>>> executeAction,
+                                            final ErrorHandler errorHandler,
+                                            final Logger logger) {
+
+    try {
+      return executeAction.get()
+        .andThen(objectResponse -> toResponse(objectResponse, request, mediaTypeMapper, errorHandler, logger));
+    } catch(Exception ex) {
+      return Completes.withFailure( ResourceErrorProcessor.resourceHandlerError(errorHandler, logger, ex));
+    }
+  }
+
+  static Response toResponse(
+                                          final ObjectResponse<?> objectResponse,
+                                          final Request request,
+                                          final MediaTypeMapper mediaTypeMapper,
+                                          final ErrorHandler errorHandler,
+                                          final Logger logger) {
+
+      return Success.of(objectResponse.responseFrom(request, mediaTypeMapper))
+        .resolve( ex -> ResourceErrorProcessor.resourceHandlerError(errorHandler, logger, (Exception) ex),
+                  response -> response);
+
+  }
+}

--- a/src/main/java/io/vlingo/http/resource/ResourceErrorProcessor.java
+++ b/src/main/java/io/vlingo/http/resource/ResourceErrorProcessor.java
@@ -1,0 +1,26 @@
+package io.vlingo.http.resource;
+
+import io.vlingo.actors.Logger;
+import io.vlingo.common.Completes;
+import io.vlingo.http.Response;
+
+public class ResourceErrorProcessor {
+
+  static Response defaultErrorResponse() {
+    return Response.of(Response.Status.InternalServerError);
+  }
+
+  static Response resourceHandlerError(ErrorHandler errorHandler, Logger logger, Exception exception) {
+    Response response;
+    try {
+      logger.log("Exception thrown by Resource execution", exception);
+      response = (errorHandler != null) ?
+        errorHandler.handle(exception) :
+        DefaultErrorHandler.instance().handle(exception);
+    } catch (Exception errorHandlerException) {
+      logger.log("Exception thrown by error handler when handling error", exception);
+      response = defaultErrorResponse();
+    }
+    return response;
+  }
+}

--- a/src/test/java/io/vlingo/http/media/AcceptMediaTypeTest.java
+++ b/src/test/java/io/vlingo/http/media/AcceptMediaTypeTest.java
@@ -1,0 +1,51 @@
+package io.vlingo.http.media;
+
+import io.vlingo.http.media.ResponseMediaTypeSelector.AcceptMediaType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AcceptMediaTypeTest {
+
+  @Test
+  public void specificMimeTypeGreaterThanGeneric() {
+    AcceptMediaType acceptMediaType1 = new AcceptMediaType("application", "json");
+    AcceptMediaType acceptMediaType2 = new AcceptMediaType("*", "*");
+    assertEquals( 1, acceptMediaType1.compareTo(acceptMediaType2));
+    assertEquals( -1, acceptMediaType2.compareTo(acceptMediaType1));
+  }
+
+  @Test
+  public void specificMimeSubTypeGreaterThanGeneric() {
+    AcceptMediaType acceptMediaType1 = new AcceptMediaType("application", "json");
+    AcceptMediaType acceptMediaType2 = new AcceptMediaType("application", "*");
+    assertEquals( 1, acceptMediaType1.compareTo(acceptMediaType2));
+    assertEquals( -1, acceptMediaType2.compareTo(acceptMediaType1));
+  }
+
+  @Test
+  public void specificParameterGreaterThanGenericWithSameQualityFactor() {
+    AcceptMediaType acceptMediaType1 = new MediaTypeDescriptor.Builder<>(AcceptMediaType::new)
+      .withMimeType("application").withMimeSubType("xml").withParameter("version", "1.0")
+      .build();
+
+    AcceptMediaType acceptMediaType2 = new AcceptMediaType("application", "json");
+    assertEquals( 1, acceptMediaType1.compareTo(acceptMediaType2));
+    assertEquals( -1, acceptMediaType2.compareTo(acceptMediaType1));
+  }
+
+  @Test
+  public void qualityFactorTrumpsSpecificity() {
+    AcceptMediaType acceptMediaType1 = new MediaTypeDescriptor.Builder<>(AcceptMediaType::new)
+      .withMimeType("text").withMimeSubType("*")
+      .build();
+
+    AcceptMediaType acceptMediaType2 = new MediaTypeDescriptor.Builder<>(AcceptMediaType::new)
+      .withMimeType("text").withMimeSubType("json")
+      .withParameter("q", "0.8")
+      .build();
+
+    assertEquals( 1, acceptMediaType1.compareTo(acceptMediaType2));
+    assertEquals( -1, acceptMediaType2.compareTo(acceptMediaType1));
+  }
+}

--- a/src/test/java/io/vlingo/http/media/ContentMediaTypeTest.java
+++ b/src/test/java/io/vlingo/http/media/ContentMediaTypeTest.java
@@ -1,0 +1,39 @@
+package io.vlingo.http.media;
+
+import io.vlingo.http.resource.MediaTypeNotSupportedException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ContentMediaTypeTest {
+
+  @Test(expected = MediaTypeNotSupportedException.class)
+  public void wildCardsAreNotAllowed() {
+    new ContentMediaType("application", "*");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void invalidMimeTypeNotAllowed() {
+   new ContentMediaType("unknownMimeType", "foo");
+  }
+
+  @Test
+  public void builderCreates() {
+    ContentMediaType.Builder<ContentMediaType> builder = new ContentMediaType.Builder<>(ContentMediaType::new);
+    ContentMediaType contentMediaType = builder
+      .withMimeType(ContentMediaType.mimeTypes.application.name())
+      .withMimeSubType("json")
+      .build();
+
+    assertEquals(ContentMediaType.Json(), contentMediaType);
+  }
+
+  @Test
+  public void builtInTypesHaveCorrectFormat() {
+    ContentMediaType jsonType = new ContentMediaType("application", "json");
+    assertEquals(jsonType, ContentMediaType.Json());
+
+    ContentMediaType xmlType = new ContentMediaType("application", "xml");
+    assertEquals(xmlType, ContentMediaType.Xml());
+  }
+}

--- a/src/test/java/io/vlingo/http/media/MediaTypeParserTest.java
+++ b/src/test/java/io/vlingo/http/media/MediaTypeParserTest.java
@@ -1,0 +1,61 @@
+package io.vlingo.http.media;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class MediaTypeParserTest {
+
+  public MediaTypeParserTest() {
+  }
+
+  private MediaTypeTest parse(String descriptor) {
+    return MediaTypeParser.parseFrom(descriptor, new MediaTypeDescriptor.Builder<>(MediaTypeTest::new));
+  }
+
+  @Test
+  public void simpleTypeEmptyParameters() {
+    MediaTypeTest mediaType = parse("application/json");
+    MediaTypeTest mediaTypeExpected = new MediaTypeDescriptor.Builder<>(MediaTypeTest::new)
+      .withMimeType("application")
+      .withMimeSubType("json")
+      .build();
+
+    assertEquals(mediaTypeExpected, mediaType);
+  }
+
+  @Test
+  public void parseParameters() {
+    MediaTypeTest mediaTypeDescriptor = parse("application/*;q=0.8;foo=bar");
+
+    MediaTypeTest mediaTypeExpected = new MediaTypeDescriptor.Builder<>(MediaTypeTest::new)
+      .withMimeType("application")
+      .withMimeSubType("*")
+      .withParameter("q", "0.8")
+      .withParameter("foo", "bar")
+      .build();
+
+    assertEquals(mediaTypeExpected, mediaTypeDescriptor);
+    assertEquals("application/*;q=0.8;foo=bar", mediaTypeDescriptor.toString());
+  }
+
+  @Test
+  public void incorrectFormatUsesEmptyStringAndDefaultQuality() {
+    MediaTypeTest mediaType = parse("typeOnly");
+    MediaTypeTest mediaTypeExpected = new MediaTypeDescriptor.Builder<>(MediaTypeTest::new)
+      .withMimeType("").withMimeSubType("")
+      .build();
+
+    assertEquals(mediaTypeExpected, mediaType);
+  }
+
+  static class MediaTypeTest extends MediaTypeDescriptor {
+
+    public MediaTypeTest(String mimeType, String mimeSubType, Map<String, String> parameters) {
+      super(mimeType, mimeSubType, parameters);
+    }
+
+  }
+}

--- a/src/test/java/io/vlingo/http/media/ResponseContentMediaTypeSelectorTest.java
+++ b/src/test/java/io/vlingo/http/media/ResponseContentMediaTypeSelectorTest.java
@@ -1,0 +1,40 @@
+package io.vlingo.http.media;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ResponseContentMediaTypeSelectorTest {
+
+  @Test
+  public void single_media_type_matches() {
+    final String  specificTypeAccepted = "application/json";
+    ResponseMediaTypeSelector selector = new ResponseMediaTypeSelector(specificTypeAccepted);
+    ContentMediaType selected = selector.selectType(new ContentMediaType[]{ContentMediaType.Json()});
+    assertEquals(ContentMediaType.Json(), selected);
+  }
+
+  @Test
+  public void wild_card_media_type_matches() {
+    final String  xmlAndJsonSuperTypeAccepted = "application/*";
+    ResponseMediaTypeSelector selector = new ResponseMediaTypeSelector(xmlAndJsonSuperTypeAccepted);
+    ContentMediaType selected = selector.selectType(new ContentMediaType[]{ContentMediaType.Json()});
+    assertEquals(ContentMediaType.Json(), selected);
+  }
+
+  @Test
+  public void generic_media_type_select_by_order_of_media_type() {
+    final String  xmlAndJsonSuperTypeAccepted = "application/*";
+    ResponseMediaTypeSelector selector = new ResponseMediaTypeSelector(xmlAndJsonSuperTypeAccepted);
+    ContentMediaType selected = selector.selectType(new ContentMediaType[]{ContentMediaType.Xml(), ContentMediaType.Json()});
+    assertEquals(ContentMediaType.Xml(), selected);
+  }
+
+  @Test
+  public void specific_media_type_select_highest_ranked() {
+    final String  jsonHigherPriorityXmlLowerPriorityAccepted = "application/xml;q=0.8, application/json";
+    ResponseMediaTypeSelector selector = new ResponseMediaTypeSelector(jsonHigherPriorityXmlLowerPriorityAccepted);
+    ContentMediaType selected = selector.selectType(new ContentMediaType[]{ContentMediaType.Xml(), ContentMediaType.Json()});
+    assertEquals(ContentMediaType.Json(), selected);
+  }
+}

--- a/src/test/java/io/vlingo/http/resource/MediaTypeMapperTest.java
+++ b/src/test/java/io/vlingo/http/resource/MediaTypeMapperTest.java
@@ -1,0 +1,51 @@
+package io.vlingo.http.resource;
+
+import io.vlingo.http.media.ContentMediaType;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MediaTypeMapperTest {
+
+  private class TestMapper<T> implements Mapper {
+
+    String returnString;
+    T returnObject;
+
+    public TestMapper(T mappedToObject, String mappedToString) {
+      this.returnObject = mappedToObject;
+      this.returnString = mappedToString;
+    }
+
+    @Override
+    public <T> T from(String data, Class<T> type) {
+      return (T)returnObject;
+    }
+
+    @Override
+    public <T> String from(T data) {
+      return returnString;
+    }
+  }
+
+  @Test
+  public void registered_mapper_maps_type() {
+    final Object mappedToObject = new Object();
+    final String mappedToString = "mappedToString";
+
+    TestMapper<Object> testMapper = new TestMapper<>(mappedToObject, mappedToString);
+    MediaTypeMapper mediaTypeMapper = new MediaTypeMapper.Builder()
+      .addMapperFor(ContentMediaType.Json(), testMapper)
+      .build();
+
+    assertEquals(mappedToString, mediaTypeMapper.from(new Object(), ContentMediaType.Json(), Object.class));
+  }
+
+  @Test(expected = MediaTypeNotSupportedException.class)
+  public void exception_thrown_for_invalid_mapper() {
+    MediaTypeMapper mediaTypeMapper = new MediaTypeMapper.Builder()
+      .build();
+    mediaTypeMapper.from(new Object(), ContentMediaType.Json(), Object.class);
+  }
+
+}

--- a/src/test/java/io/vlingo/http/resource/ParameterResolverTest.java
+++ b/src/test/java/io/vlingo/http/resource/ParameterResolverTest.java
@@ -1,6 +1,7 @@
 package io.vlingo.http.resource;
 
 import io.vlingo.http.*;
+import io.vlingo.http.media.ContentMediaType;
 import io.vlingo.http.sample.user.NameData;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,6 +41,21 @@ public class ParameterResolverTest {
   @Test
   public void body() {
     final ParameterResolver<NameData> resolver = ParameterResolver.body(NameData.class);
+
+    final NameData result = resolver.apply(request, mappedParameters);
+    final NameData expected = new NameData("John", "Doe");
+
+    assertEquals(expected.toString(), result.toString());
+    assertEquals(ParameterResolver.Type.BODY, resolver.type);
+  }
+
+  @Test
+  public void bodyWithContentTypeMapper() {
+    final MediaTypeMapper mediaTypeMapper = new MediaTypeMapper.Builder()
+      .addMapperFor(ContentMediaType.Json(), DefaultJsonMapper.instance)
+      .build();
+
+    final ParameterResolver<NameData> resolver = ParameterResolver.body(NameData.class, mediaTypeMapper);
 
     final NameData result = resolver.apply(request, mappedParameters);
     final NameData expected = new NameData("John", "Doe");

--- a/src/test/java/io/vlingo/http/resource/RequestHandler0Test.java
+++ b/src/test/java/io/vlingo/http/resource/RequestHandler0Test.java
@@ -11,7 +11,10 @@ package io.vlingo.http.resource;
 
 import io.vlingo.common.Completes;
 import io.vlingo.http.*;
+import io.vlingo.http.media.ContentMediaType;
+import io.vlingo.http.resource.serialization.JsonSerialization;
 import io.vlingo.http.sample.user.NameData;
+import io.vlingo.http.sample.user.model.Name;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -20,8 +23,7 @@ import java.net.URI;
 import java.util.Collections;
 
 import static io.vlingo.common.Completes.withSuccess;
-import static io.vlingo.http.Response.Status.Created;
-import static io.vlingo.http.Response.Status.Imateapot;
+import static io.vlingo.http.Response.Status.*;
 import static io.vlingo.http.Response.of;
 import static io.vlingo.http.resource.ParameterResolver.*;
 import static org.junit.Assert.assertEquals;
@@ -36,7 +38,7 @@ public class RequestHandler0Test extends RequestHandlerTestBase {
   public void simpleHandler() {
     final RequestHandler0 handler = new RequestHandler0(Method.GET, "/helloworld")
       .handle(() -> withSuccess(of(Created)));
-    final Response response = handler.execute(logger).outcome();
+    final Response response = handler.execute(Request.method(Method.GET), logger).outcome();
 
     assertNotNull(handler);
     assertEquals(Method.GET, handler.method);
@@ -44,17 +46,13 @@ public class RequestHandler0Test extends RequestHandlerTestBase {
     assertResponsesAreEquals(of(Created), response);
   }
 
-  @Test
-  public void errorHandlerInvoked() {
-    final RequestHandler0 handler = new RequestHandler0(Method.GET, "/helloworld")
-      .handle(() -> {
-        throw new RuntimeException("Test Handler exception");
-      })
-      .onError(
-        (error) -> Completes.withSuccess(Response.of(Response.Status.Imateapot))
-    );
-    Completes<Response> responseCompletes = handler.execute(logger);
-    assertResponsesAreEquals(Response.of(Imateapot), responseCompletes.await());
+  @Test()
+  public void throwExceptionWhenNoHandlerIsDefined() {
+    thrown.expect(HandlerMissingException.class);
+    thrown.expectMessage("No handler defined for GET /helloworld");
+
+    final RequestHandler0 handler = new RequestHandler0(Method.GET, "/helloworld");
+    handler.execute(Request.method(Method.GET), logger);
   }
 
   @Test
@@ -72,7 +70,6 @@ public class RequestHandler0Test extends RequestHandlerTestBase {
       .and(Version.Http1_1);
     final Action.MappedParameters mappedParameters =
       new Action.MappedParameters(1, Method.GET, "ignored", Collections.emptyList());
-
     final RequestHandler0 handler = new RequestHandler0(Method.GET, "/helloworld")
       .handle(() -> withSuccess(of(Created)));
     final Response response = handler.execute(request, mappedParameters, logger).outcome();
@@ -121,6 +118,7 @@ public class RequestHandler0Test extends RequestHandlerTestBase {
   }
 
   @Test
+  @SuppressWarnings( "deprecation" )
   public void addingHandlerBodyWithMapper() {
     final Request request = Request.has(Method.POST)
                                    .and(URI.create("/user/admin/name"))
@@ -133,6 +131,26 @@ public class RequestHandler0Test extends RequestHandlerTestBase {
 
     final RequestHandler1<NameData> handler1 = new RequestHandler0(Method.GET, "/user/admin/name")
       .body(NameData.class, TestMapper.class);
+
+    assertResolvesAreEquals(body(NameData.class, new TestMapper()), handler1.resolver);
+    assertEquals(new NameData("John", "Doe"), handler1.resolver.apply(request, mappedParameters));
+  }
+
+
+  @Test
+  public void addingHandlerBodyWithMediaTypeMapper() {
+    final Request request = Request.has(Method.POST)
+                                   .and(URI.create("/user/admin/name"))
+                                   .and(Body.from("{\"given\":\"John\",\"family\":\"Doe\"}"))
+                                   .and(RequestHeader.of(RequestHeader.ContentType, "application/json"))
+                                   .and(Version.Http1_1);
+    final Action.MappedParameters mappedParameters =
+      new Action.MappedParameters(1, Method.POST, "ignored", Collections.singletonList(
+        new Action.MappedParameter("String", "admin"))
+      );
+
+    final RequestHandler1<NameData> handler1 = new RequestHandler0(Method.GET, "/user/admin/name")
+      .body(NameData.class);
 
     assertResolvesAreEquals(body(NameData.class, new TestMapper()), handler1.resolver);
     assertEquals(new NameData("John", "Doe"), handler1.resolver.apply(request, mappedParameters));

--- a/src/test/java/io/vlingo/http/resource/RequestHandler3Test.java
+++ b/src/test/java/io/vlingo/http/resource/RequestHandler3Test.java
@@ -11,6 +11,7 @@ package io.vlingo.http.resource;
 
 import io.vlingo.common.Completes;
 import io.vlingo.http.*;
+import io.vlingo.http.resource.RequestHandler3.Handler3;
 import io.vlingo.http.sample.user.NameData;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,7 +43,8 @@ public class RequestHandler3Test extends RequestHandlerTestBase {
       parameterResolver1,
       parameterResolver2,
       parameterResolver3,
-      ErrorHandler.handleAllWith(InternalServerError));
+      ErrorHandler.handleAllWith(InternalServerError),
+      DefaultMediaTypeMapper.instance());
   }
 
   @Test
@@ -53,9 +55,10 @@ public class RequestHandler3Test extends RequestHandlerTestBase {
       path(0, String.class),
       path(1, String.class),
       query("page", Integer.class, 10)
-    ).handle((postId, commentId, page) -> withSuccess(of(Ok, serialized(postId + " " + commentId))));
+    ).handle((Handler3<String, String, Integer>) (postId, commentId, page)
+      -> withSuccess(of(Ok, serialized(postId + " " + commentId))));
 
-    final Response response = handler.execute("my-post", "my-comment", null, logger).outcome();
+    final Response response = handler.execute(Request.method(Method.GET), "my-post", "my-comment", null, logger).outcome();
 
     assertNotNull(handler);
     assertEquals(Method.GET, handler.method);
@@ -68,7 +71,7 @@ public class RequestHandler3Test extends RequestHandlerTestBase {
   @Test()
   public void throwExceptionWhenNoHandlerIsDefined() {
     thrown.expect(HandlerMissingException.class);
-    thrown.expectMessage("No handle defined for GET /posts/{postId}");
+    thrown.expectMessage("No handler defined for GET /posts/{postId}/comment/{commentId}");
 
     final RequestHandler3<String, String, Integer> handler = createRequestHandler(
       Method.GET,
@@ -77,23 +80,7 @@ public class RequestHandler3Test extends RequestHandlerTestBase {
       path(1, String.class),
       query("page", Integer.class, 10)
     );
-    handler.execute("my-post", "my-comment", 1, logger);
-  }
-
-  @Test
-  public void errorHandlerInvoked() {
-    final RequestHandler3<String, String, Integer> handler = createRequestHandler(
-      Method.GET,
-      "/posts/{postId}/comment/{commentId}",
-      path(0, String.class),
-      path(1, String.class),
-      query("page", Integer.class, 10))
-      .handle((param1, param2, param3) -> { throw new RuntimeException("Test Handler exception"); })
-      .onError(
-        (error) -> Completes.withSuccess(Response.of(Response.Status.Imateapot))
-      );
-    Completes<Response> responseCompletes = handler.execute("idVal1", "idVal2", 1, logger);
-    assertResponsesAreEquals(Response.of(Imateapot), responseCompletes.await());
+    handler.execute(Request.method(Method.GET), "my-post", "my-comment", 1, logger);
   }
 
   @Test
@@ -126,7 +113,7 @@ public class RequestHandler3Test extends RequestHandlerTestBase {
       path(1, String.class),
       query("page", Integer.class, 10)
     )
-      .handle((postId, commentId, page) -> withSuccess(of(Ok, serialized(postId + " " + commentId))));
+      .handle((Handler3<String,String,Integer>)(postId, commentId, page) -> withSuccess(of(Ok, serialized(postId + " " + commentId))));
     final Response response = handler.execute(request, mappedParameters, logger).outcome();
 
     assertResponsesAreEquals(of(Ok, serialized("my-post my-comment")), response);
@@ -188,6 +175,7 @@ public class RequestHandler3Test extends RequestHandlerTestBase {
   }
 
 
+  @SuppressWarnings("deprecation")
   @Test
   public void addingHandlerBodyWithMapper() {
     final Request request = Request.has(Method.POST)

--- a/src/test/java/io/vlingo/http/resource/RequestHandlerTest.java
+++ b/src/test/java/io/vlingo/http/resource/RequestHandlerTest.java
@@ -5,7 +5,11 @@ import io.vlingo.common.Completes;
 import io.vlingo.http.Method;
 import io.vlingo.http.Request;
 import io.vlingo.http.Response;
+import io.vlingo.http.ResponseHeader;
+import io.vlingo.http.media.ContentMediaType;
+import io.vlingo.http.resource.serialization.JsonSerialization;
 import io.vlingo.http.sample.user.NameData;
+import io.vlingo.http.sample.user.model.Name;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -13,9 +17,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Supplier;
 
-import static io.vlingo.http.Response.Status.InternalServerError;
+import static io.vlingo.http.Response.Status.*;
+import static io.vlingo.http.resource.RequestHandler0.*;
 import static org.junit.Assert.assertEquals;
 
 public class RequestHandlerTest extends RequestHandlerTestBase {
@@ -30,12 +34,30 @@ public class RequestHandlerTest extends RequestHandlerTestBase {
       () -> { throw new RuntimeException("Handler failed"); }
     );
 
-    ErrorHandler validHandler = (exception) -> {
+    ErrorHandler customHandler = (exception) -> {
       Assert.assertTrue( exception instanceof RuntimeException);
-      return Completes.withSuccess(Response.of(testStatus));
+      return Response.of(testStatus);
     };
 
-    Response response = handler.execute(validHandler, logger).await();
+    Response response = handler.execute(Request.method(Method.GET), customHandler, logger).await();
+    assertResponsesAreEquals(Response.of(testStatus), response);
+  }
+
+  @Test
+  public void executionErrorObjectUsesErrorHandlerWhenExceptionThrown() {
+    final Response.Status testStatus = Response.Status.BadRequest;
+    final ErrorHandler validHandler = (exception) -> {
+      Assert.assertTrue( exception instanceof RuntimeException);
+      return Response.of(testStatus);
+    };
+
+    final RequestObjectHandlerFake handler = new RequestObjectHandlerFake(Method.GET,
+      "/hello",
+      validHandler,
+      () -> { throw new RuntimeException("Handler failed"); }
+    );
+
+    Response response = handler.execute(Request.method(Method.GET), null, logger).await();
     assertResponsesAreEquals(Response.of(testStatus), response);
   }
 
@@ -51,7 +73,7 @@ public class RequestHandlerTest extends RequestHandlerTestBase {
       throw new IllegalArgumentException("foo");
     };
 
-    Response response = handler.execute(badHandler, logger).await();
+    Response response = handler.execute(Request.method(Method.GET), badHandler, logger).await();
     assertResponsesAreEquals(Response.of(InternalServerError), response);
   }
 
@@ -63,10 +85,38 @@ public class RequestHandlerTest extends RequestHandlerTestBase {
       () -> { throw new RuntimeException("Handler failed"); }
     );
 
-    Response response = handler.execute(null, logger).await();
+    Response response = handler.execute(Request.method(Method.GET), (ErrorHandler) null, logger).await();
     assertResponsesAreEquals(Response.of(InternalServerError), response);
   }
 
+  @Test
+  public void mappingNotAvailableReturnsMediaTypeNotFoundResponse() {
+    final RequestHandlerFake handler = new RequestHandlerFake(Method.GET,
+      "/hello",
+      new ArrayList<>(),
+      () -> { throw new MediaTypeNotSupportedException("foo/bar"); }
+    );
+
+    Response response = handler.execute(Request.method(Method.GET), (ErrorHandler)null, logger).await();
+    assertResponsesAreEquals(Response.of(UnsupportedMediaType), response);
+  }
+
+  @Test
+  public void objectResponseMappedToContentType() {
+    final Name name = new Name("first", "last");
+    final RequestObjectHandlerFake handler = new RequestObjectHandlerFake(Method.GET,
+      "/hello",
+      () -> Completes.withSuccess(ObjectResponse.of(Ok, name, Name.class))
+    );
+
+    Response response = handler.execute(Request.method(Method.GET), null, logger).await();
+    String nameAsJson = JsonSerialization.serialized(name);
+    assertResponsesAreEquals(
+      Response.of(Ok,
+                  ResponseHeader.headers(ResponseHeader.ContentType, ContentMediaType.Json().toString()),
+                  nameAsJson),
+      response);
+  }
 
 
   @Test
@@ -118,20 +168,50 @@ public class RequestHandlerTest extends RequestHandlerTestBase {
   }
 }
 
+class RequestObjectHandlerFake extends RequestHandler {
+
+  private ParamExecutor0 executor;
+  private ErrorHandler errorHandler;
+
+  RequestObjectHandlerFake(Method method, String path, ObjectHandler0 handler) {
+    super(method, path, new ArrayList<>());
+    this.executor = (request, mediaTypeMapper1, errorHandler1, logger) ->
+      RequestObjectExecutor.executeRequest(request, mediaTypeMapper1, () -> handler.execute(), errorHandler, logger);
+    this.errorHandler = null;
+  }
+
+  RequestObjectHandlerFake(Method method, String path, ErrorHandler errorHandler, ObjectHandler0 handler) {
+    super(method, path, new ArrayList<>());
+    executor = ((request, mediaTypeMapper1, errorHandler1, logger1) ->
+      RequestObjectExecutor.executeRequest(request, mediaTypeMapper1, () -> handler.execute(), errorHandler1, logger1));
+    this.errorHandler = errorHandler;
+  }
+
+  @Override
+  Completes<Response> execute(Request request, Action.MappedParameters mappedParameters, Logger logger) {
+   return executor.execute(request,
+                           DefaultMediaTypeMapper.instance(),
+                           errorHandler, logger);
+  }
+
+}
+
 class RequestHandlerFake extends RequestHandler {
 
-  Supplier<Completes<Response>> handler;
+  ParamExecutor0 executor;
 
-  RequestHandlerFake(Method method, String path, List<ParameterResolver<?>> parameterResolvers) {
+  RequestHandlerFake(final Method method, final String path, final List<ParameterResolver<?>> parameterResolvers) {
     super(method, path, parameterResolvers);
-    handler = () -> Completes.withSuccess(Response.of(Response.Status.Ok));
+    executor = ((request, mediaTypeMapper1, errorHandler1, logger1) ->
+      RequestExecutor.executeRequest(() -> Completes.withSuccess(Response.of(Ok)), errorHandler1, logger1));
   }
 
   RequestHandlerFake(Method method, String path,
                      List<ParameterResolver<?>> parameterResolvers,
-                     Supplier<Completes<Response>> handler) {
+                     Handler0 handler) {
     super(method, path, parameterResolvers);
-    this.handler = handler;
+    executor = ((request, mediaTypeMapper1, errorHandler1, logger1) ->
+      RequestExecutor.executeRequest(handler::execute, errorHandler1, logger1));
   }
 
   @Override
@@ -141,8 +221,8 @@ class RequestHandlerFake extends RequestHandler {
     throw new UnsupportedOperationException();
   }
 
-  Completes<Response> execute(ErrorHandler errorHandler, Logger logger) {
-    return executeRequest(handler, errorHandler, logger);
+  Completes<Response> execute(Request request, ErrorHandler errorHandler, Logger logger) {
+    return executor.execute(request, null, errorHandler, logger);
   }
 
 }

--- a/src/test/java/io/vlingo/http/resource/RequestHandlerTestBase.java
+++ b/src/test/java/io/vlingo/http/resource/RequestHandlerTestBase.java
@@ -12,6 +12,7 @@ package io.vlingo.http.resource;
 import static org.junit.Assert.assertEquals;
 
 import io.vlingo.actors.Logger;
+import io.vlingo.http.media.ContentMediaType;
 import io.vlingo.http.Response;
 
 public class RequestHandlerTestBase {
@@ -29,5 +30,12 @@ public class RequestHandlerTestBase {
   <T> void assertResolvesAreEquals(final ParameterResolver<T> expected, final ParameterResolver<T> actual) {
     assertEquals(expected.type, actual.type);
     assertEquals(expected.paramClass, actual.paramClass);
+  }
+
+  MediaTypeMapper defaultMediaTypeMapperForJson() {
+
+    return new MediaTypeMapper.Builder()
+      .addMapperFor(ContentMediaType.Json(), new DefaultJsonMapper())
+      .build();
   }
 }

--- a/src/test/java/io/vlingo/http/resource/ResourceBuilderTest.java
+++ b/src/test/java/io/vlingo/http/resource/ResourceBuilderTest.java
@@ -33,7 +33,7 @@ public class ResourceBuilderTest extends ResourceTestFixtures {
         post("/post/{postId}")
           .param(String.class)
           .body(UserData.class)
-          .handle((postId, userData) -> Completes.withSuccess(Response.of(Ok, serialized(postId))))
+          .handle((RequestHandler2.Handler2<String, UserData>) (postId, userData) -> Completes.withSuccess(Response.of(Ok, serialized(postId))))
       );
 
     assertNotNull(resource);
@@ -48,11 +48,11 @@ public class ResourceBuilderTest extends ResourceTestFixtures {
       get("/customers/{customerId}/accounts/{accountId}")
         .param(String.class)
         .param(String.class)
-        .handle((customerId, accountID) -> Completes.withSuccess((Response.of(Ok, serialized("users"))))),
+        .handle((RequestHandler2.Handler2<String, String>) (customerId, accountID) -> Completes.withSuccess((Response.of(Ok, serialized("users"))))),
       get("/customers/{customerId}/accounts/{accountId}/withdraw")
         .param(String.class)
         .param(String.class)
-        .handle((customerId, accountID) -> Completes.withSuccess((Response.of(Ok, serialized("user admin")))))
+        .handle((RequestHandler2.Handler2<String, String>) (customerId, accountID) -> Completes.withSuccess((Response.of(Ok, serialized("user admin")))))
     );
 
     final Action.MatchResults matchWithdrawResource = resource.matchWith(

--- a/src/test/java/io/vlingo/http/sample/user/AllSseFeedActor.java
+++ b/src/test/java/io/vlingo/http/sample/user/AllSseFeedActor.java
@@ -58,7 +58,7 @@ public class AllSseFeedActor extends Actor implements SseFeed {
     int type = 0;
     int id = startId;
     for ( ; id <= endId; ++id) {
-      substream.add(builder.clear().event("type-" + ('A' + type)).id(id).data("data-" + id).retry(retry).toEvent());
+      substream.add(builder.clear().event("mimeType-" + ('A' + type)).id(id).data("data-" + id).retry(retry).toEvent());
       type = type > 26 ? 0 : type + 1;
     }
 

--- a/src/test/java/io/vlingo/http/sample/user/ProfileDataMapper.java
+++ b/src/test/java/io/vlingo/http/sample/user/ProfileDataMapper.java
@@ -7,7 +7,7 @@
 
 package io.vlingo.http.sample.user;
 
-import io.vlingo.http.resource.DefaultMapper;
+import io.vlingo.http.resource.DefaultJsonMapper;
 import io.vlingo.http.resource.Mapper;
 
 /**
@@ -24,11 +24,11 @@ public class ProfileDataMapper implements Mapper {
 
   @Override
   public <T> T from(final String data, final Class<T> type) {
-    return DefaultMapper.instance.from(data, type);
+    return DefaultJsonMapper.instance.from(data, type);
   }
 
   @Override
   public <T> String from(final T data) {
-    return DefaultMapper.instance.from(data);
+    return DefaultJsonMapper.instance.from(data);
   }
 }


### PR DESCRIPTION
* Content type negotiation via Accept header when returning content
* Mappers decodes POST body based on Content-type header
* Added new Handler functional type that allows returning Objects.  These are deserialized to the most appropriate type for the client, or Json by default.
(Squash of https://github.com/vlingo/vlingo-http/pull/36)