### PR TITLE
eliminate bare TestUntil in MockResponseSenderChannel (issue #33)

### DIFF
--- a/src/test/java/io/vlingo/http/resource/TestDispatcher.java
+++ b/src/test/java/io/vlingo/http/resource/TestDispatcher.java
@@ -8,7 +8,6 @@
 package io.vlingo.http.resource;
 
 import io.vlingo.actors.Logger;
-import io.vlingo.actors.plugin.logging.jdk.JDKLogger;
 import io.vlingo.http.Context;
 
 public class TestDispatcher implements Dispatcher {
@@ -17,7 +16,7 @@ public class TestDispatcher implements Dispatcher {
 
   public TestDispatcher(final Resources resources) {
     this.resources = resources;
-    this.logger = JDKLogger.testInstance();
+    this.logger = Logger.noOpLogger();
   }
 
   @Override

--- a/src/test/java/io/vlingo/http/resource/sse/SseFeedTest.java
+++ b/src/test/java/io/vlingo/http/resource/sse/SseFeedTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import io.vlingo.actors.Definition;
 import io.vlingo.actors.World;
+import io.vlingo.actors.testkit.AccessSafely;
 import io.vlingo.http.resource.Configuration;
 import io.vlingo.http.sample.user.AllSseFeedActor;
 
@@ -32,11 +33,11 @@ public class SseFeedTest {
 
     final SseSubscriber subscriber = new SseSubscriber("all", client, "ABC123", "42");
 
-    context.channel.expectRespondWith(1);
+    final AccessSafely respondWithSafely = context.channel.expectRespondWith(1);
 
     feed.to(Arrays.asList(subscriber));
 
-    context.channel.untilCompletes();
+    assertEquals(1, (int) respondWithSafely.readFrom("count"));
 
     assertEquals(1, context.channel.respondWithCount.get());
 
@@ -53,11 +54,11 @@ public class SseFeedTest {
     final SseSubscriber subscriber2 = new SseSubscriber("all", client, "ABC456", "42");
     final SseSubscriber subscriber3 = new SseSubscriber("all", client, "ABC789", "43");
 
-    context.channel.expectRespondWith(3);
+    final AccessSafely respondWithSafely = context.channel.expectRespondWith(3);
 
     feed.to(Arrays.asList(subscriber1, subscriber2, subscriber3));
 
-    context.channel.untilCompletes();
+    assertEquals(3, (int) respondWithSafely.readFrom("count"));
 
     assertEquals(3, context.channel.respondWithCount.get());
   }

--- a/src/test/java/io/vlingo/http/resource/sse/SseFeedTest.java
+++ b/src/test/java/io/vlingo/http/resource/sse/SseFeedTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 
 import io.vlingo.actors.Definition;
 import io.vlingo.actors.World;
-import io.vlingo.actors.testkit.TestUntil;
 import io.vlingo.http.resource.Configuration;
 import io.vlingo.http.sample.user.AllSseFeedActor;
 
@@ -33,11 +32,11 @@ public class SseFeedTest {
 
     final SseSubscriber subscriber = new SseSubscriber("all", client, "ABC123", "42");
 
-    context.channel.untilRespondWith = TestUntil.happenings(1);
+    context.channel.expectRespondWith(1);
 
     feed.to(Arrays.asList(subscriber));
 
-    context.channel.untilRespondWith.completes();
+    context.channel.untilCompletes();
 
     assertEquals(1, context.channel.respondWithCount.get());
 
@@ -54,11 +53,11 @@ public class SseFeedTest {
     final SseSubscriber subscriber2 = new SseSubscriber("all", client, "ABC456", "42");
     final SseSubscriber subscriber3 = new SseSubscriber("all", client, "ABC789", "43");
 
-    context.channel.untilRespondWith = TestUntil.happenings(3);
+    context.channel.expectRespondWith(3);
 
     feed.to(Arrays.asList(subscriber1, subscriber2, subscriber3));
 
-    context.channel.untilRespondWith.completes();
+    context.channel.untilCompletes();
 
     assertEquals(3, context.channel.respondWithCount.get());
   }

--- a/src/test/java/io/vlingo/http/resource/sse/SseStreamResourceTest.java
+++ b/src/test/java/io/vlingo/http/resource/sse/SseStreamResourceTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.vlingo.actors.World;
+import io.vlingo.actors.testkit.AccessSafely;
 import io.vlingo.http.Method;
 import io.vlingo.http.Request;
 import io.vlingo.http.RequestHeader;
@@ -33,13 +34,13 @@ public class SseStreamResourceTest {
               .and(RequestHeader.host("StreamsRUs.co"))
               .and(RequestHeader.accept("text/event-stream"));
 
-    resource.requestResponseContext.channel.expectRespondWith(10);
+    final AccessSafely respondWithSafely = resource.requestResponseContext.channel.expectRespondWith(10);
 
     resource.nextRequest(request);
 
     resource.subscribeToStream("all", AllSseFeedActor.class, 10, 10, "1");
     
-    resource.requestResponseContext.channel.untilCompletes();
+    assertEquals(10, (int) respondWithSafely.readFrom("count"));
 
     assertEquals(10, resource.requestResponseContext.channel.respondWithCount.get());
   }
@@ -53,14 +54,13 @@ public class SseStreamResourceTest {
               .and(RequestHeader.host("StreamsRUs.co"))
               .and(RequestHeader.accept("text/event-stream"));
 
-    resource.requestResponseContext.channel.expectRespondWith(10);
+    final AccessSafely respondWithSafely = resource.requestResponseContext.channel.expectRespondWith(10);
 
     resource.nextRequest(subscribe);
 
     resource.subscribeToStream("all", AllSseFeedActor.class, 1, 10, "1");
     
-    resource.requestResponseContext.channel.untilCompletes();
-
+    assertTrue(1 <= (int) respondWithSafely.readFrom("count"));
     assertTrue(1 <= resource.requestResponseContext.channel.respondWithCount.get());
 
     final String clientId = resource.requestResponseContext.id();
@@ -72,14 +72,13 @@ public class SseStreamResourceTest {
               .and(RequestHeader.host("StreamsRUs.co"))
               .and(RequestHeader.accept("text/event-stream"));
 
-    resource.requestResponseContext.channel.expectAbandon(1);
+    final AccessSafely abandonSafely = resource.requestResponseContext.channel.expectAbandon(1);
 
     resource.nextRequest(unsubscribe);
 
     resource.unsubscribeFromStream("all", clientId);
     
-    resource.requestResponseContext.channel.untilCompletes();
-
+    assertEquals(1, (int) abandonSafely.readFrom("count"));
     assertEquals(1, resource.requestResponseContext.channel.abandonCount.get());
   }
 

--- a/src/test/java/io/vlingo/http/resource/sse/SseStreamResourceTest.java
+++ b/src/test/java/io/vlingo/http/resource/sse/SseStreamResourceTest.java
@@ -14,7 +14,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.vlingo.actors.World;
-import io.vlingo.actors.testkit.TestUntil;
 import io.vlingo.http.Method;
 import io.vlingo.http.Request;
 import io.vlingo.http.RequestHeader;
@@ -34,13 +33,13 @@ public class SseStreamResourceTest {
               .and(RequestHeader.host("StreamsRUs.co"))
               .and(RequestHeader.accept("text/event-stream"));
 
-    resource.requestResponseContext.channel.untilRespondWith = TestUntil.happenings(10);
+    resource.requestResponseContext.channel.expectRespondWith(10);
 
     resource.nextRequest(request);
 
     resource.subscribeToStream("all", AllSseFeedActor.class, 10, 10, "1");
     
-    resource.requestResponseContext.channel.untilRespondWith.completes();
+    resource.requestResponseContext.channel.untilCompletes();
 
     assertEquals(10, resource.requestResponseContext.channel.respondWithCount.get());
   }
@@ -54,13 +53,13 @@ public class SseStreamResourceTest {
               .and(RequestHeader.host("StreamsRUs.co"))
               .and(RequestHeader.accept("text/event-stream"));
 
-    resource.requestResponseContext.channel.untilRespondWith = TestUntil.happenings(10);
+    resource.requestResponseContext.channel.expectRespondWith(10);
 
     resource.nextRequest(subscribe);
 
     resource.subscribeToStream("all", AllSseFeedActor.class, 1, 10, "1");
     
-    resource.requestResponseContext.channel.untilRespondWith.completes();
+    resource.requestResponseContext.channel.untilCompletes();
 
     assertTrue(1 <= resource.requestResponseContext.channel.respondWithCount.get());
 
@@ -73,13 +72,13 @@ public class SseStreamResourceTest {
               .and(RequestHeader.host("StreamsRUs.co"))
               .and(RequestHeader.accept("text/event-stream"));
 
-    resource.requestResponseContext.channel.untilAbandon = TestUntil.happenings(1);
+    resource.requestResponseContext.channel.expectAbandon(1);
 
     resource.nextRequest(unsubscribe);
 
     resource.unsubscribeFromStream("all", clientId);
     
-    resource.requestResponseContext.channel.untilAbandon.completes();
+    resource.requestResponseContext.channel.untilCompletes();
 
     assertEquals(1, resource.requestResponseContext.channel.abandonCount.get());
   }

--- a/src/test/java/io/vlingo/http/resource/sse/SseSubscriberTest.java
+++ b/src/test/java/io/vlingo/http/resource/sse/SseSubscriberTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.vlingo.actors.testkit.AccessSafely;
 import io.vlingo.http.resource.Configuration;
 
 public class SseSubscriberTest {
@@ -35,7 +36,9 @@ public class SseSubscriberTest {
     assertTrue(subscriber.isCompatibleWith("all"));
     assertFalse(subscriber.isCompatibleWith("amm"));
     assertEquals(0, context.channel.abandonCount.get());
+    final AccessSafely abandonSafely = context.channel.expectAbandon(1);
     subscriber.close();
+    assertEquals(1, (int) abandonSafely.readFrom("count"));
     assertEquals(1, context.channel.abandonCount.get());
   }
 


### PR DESCRIPTION
This is only part of issue #33.  I wanted to get feedback before doing the rest.

I replaced the exposed TestUntil with an encapsulated AccessSafely.  I wrapped access to the AccessSafely because there was a lot of rigmarole to make it work for simply tracking the number of transactions.  The call order for creation requires that establishing the expected transaction count *before* adding the Consumer and Supplier.  The Consumer and Supplier (registered by calls to .writingWith and .readingWith)  turn out to be completely irrelevant boilerplate.  Calls to writeUsing and readFrom perform the synchronization, but the data are ignored.  I didn't want to spread complicated no-op code throughout the tests when I could encapsulate within the mock.  All of this seems like a lot of work to count transactions.  Wouldn't a CountDownLatch accomplish the same thing?

Thoughts?