### PR TITLE
replace JDKLogger.testInstance() with LoggerProvider.noOpLoggerProvid…

### DIFF
--- a/src/test/java/io/vlingo/http/resource/ResourceTestFixtures.java
+++ b/src/test/java/io/vlingo/http/resource/ResourceTestFixtures.java
@@ -170,7 +170,7 @@ public abstract class ResourceTestFixtures {
     oneResource.put(resource.name, resource);
 
     resources = new Resources(oneResource);
-    dispatcher = new TestDispatcher(resources);
+    dispatcher = new TestDispatcher(resources, world.defaultLogger());
   }
 
   @After

--- a/src/test/java/io/vlingo/http/resource/TestDispatcher.java
+++ b/src/test/java/io/vlingo/http/resource/TestDispatcher.java
@@ -8,16 +8,15 @@
 package io.vlingo.http.resource;
 
 import io.vlingo.actors.Logger;
-import io.vlingo.actors.LoggerProvider;
 import io.vlingo.http.Context;
 
 public class TestDispatcher implements Dispatcher {
   private final Logger logger;
   private final Resources resources;
 
-  public TestDispatcher(final Resources resources) {
+  public TestDispatcher(final Resources resources, final Logger logger) {
     this.resources = resources;
-    this.logger = LoggerProvider.noOpLoggerProvider().logger();
+    this.logger = logger;
   }
 
   @Override

--- a/src/test/java/io/vlingo/http/resource/TestDispatcher.java
+++ b/src/test/java/io/vlingo/http/resource/TestDispatcher.java
@@ -8,7 +8,7 @@
 package io.vlingo.http.resource;
 
 import io.vlingo.actors.Logger;
-import io.vlingo.actors.plugin.logging.jdk.JDKLogger;
+import io.vlingo.actors.LoggerProvider;
 import io.vlingo.http.Context;
 
 public class TestDispatcher implements Dispatcher {
@@ -17,7 +17,7 @@ public class TestDispatcher implements Dispatcher {
 
   public TestDispatcher(final Resources resources) {
     this.resources = resources;
-    this.logger = JDKLogger.testInstance();
+    this.logger = LoggerProvider.noOpLoggerProvider().logger();
   }
 
   @Override


### PR DESCRIPTION
`TestDispatcher` in `vlingo-http` references `JDKLogger` which no longer exists, resulting in compilation errors. Replaced `JDKLogger.testInstance()` with `LoggerProvider.noOpLoggerProvider().logger()`