### PR TITLE
Allow for non-encoded binary response bodies

### DIFF
--- a/src/main/java/io/vlingo/http/BinaryBody.java
+++ b/src/main/java/io/vlingo/http/BinaryBody.java
@@ -7,13 +7,15 @@
 
 package io.vlingo.http;
 
+import java.nio.charset.StandardCharsets;
+
 public class BinaryBody implements Body {
 
   public final byte[] binaryContent;
 
   @Override
   public String content() {
-    return "";
+    return new String(binaryContent, StandardCharsets.UTF_8);
   }
 
   public byte[] binaryContent() {
@@ -27,7 +29,7 @@ public class BinaryBody implements Body {
 
   @Override
   public String toString() {
-    return "";
+    return content();
   }
 
 

--- a/src/main/java/io/vlingo/http/BinaryBody.java
+++ b/src/main/java/io/vlingo/http/BinaryBody.java
@@ -1,0 +1,41 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
+package io.vlingo.http;
+
+public class BinaryBody implements Body {
+
+  public final byte[] binaryContent;
+
+  @Override
+  public String content() {
+    return "";
+  }
+
+  public byte[] binaryContent() {
+    return binaryContent;
+  }
+
+  @Override
+  public boolean hasContent() {
+    return !(binaryContent.length == 0);
+  }
+
+  @Override
+  public String toString() {
+    return "";
+  }
+
+
+  BinaryBody(final byte[] body) {
+    this.binaryContent = body;
+  }
+
+  BinaryBody() {
+    this.binaryContent = new byte[0];
+  }
+}

--- a/src/main/java/io/vlingo/http/BinaryBody.java
+++ b/src/main/java/io/vlingo/http/BinaryBody.java
@@ -15,7 +15,7 @@ public class BinaryBody implements Body {
 
   @Override
   public String content() {
-    return new String(binaryContent, StandardCharsets.UTF_8);
+    return Body.bytesToBase64(binaryContent);
   }
 
   public byte[] binaryContent() {

--- a/src/main/java/io/vlingo/http/Body.java
+++ b/src/main/java/io/vlingo/http/Body.java
@@ -15,7 +15,7 @@ import java.util.Base64;
  * An HTTP request/response body, with concrete subclass {@code PlainBody} and {@code ChunkedBody}.
  */
 public interface Body {
-  enum Encoding { Base64, UTF8 };
+  enum Encoding { Base64, UTF8, None };
 
   /** An empty {@code PlainBody}. */
   static final Body Empty = new PlainBody();
@@ -66,6 +66,8 @@ public interface Body {
       return new PlainBody(bytesToBase64(body));
     case UTF8:
       return new PlainBody(bytesToUTF8(body));
+    case None:
+      return new BinaryBody(body);
     }
     throw new IllegalArgumentException("Unmapped encoding: " + encoding);
   }
@@ -82,6 +84,8 @@ public interface Body {
       return new PlainBody(bytesToBase64(bufferToArray(body)));
     case UTF8:
       return new PlainBody(bytesToUTF8(bufferToArray(body)));
+    case None:
+      return new BinaryBody(bufferToArray(body));
     }
     throw new IllegalArgumentException("Unmapped encoding: " + encoding);
   }
@@ -118,6 +122,12 @@ public interface Body {
    * @return String
    */
   String content();
+
+  /**
+   * Answer my content as a {@code byte[]}.
+   * @return byte[]
+   */
+  byte[] binaryContent();
 
   /**
    * Answer whether or not this {@code Body} content is complex.

--- a/src/main/java/io/vlingo/http/ChunkedBody.java
+++ b/src/main/java/io/vlingo/http/ChunkedBody.java
@@ -41,6 +41,15 @@ public class ChunkedBody implements Body {
   }
 
   /**
+   * Answer self after appending the {@code byte[]}.
+   * @param chunk the byte[] content to append as the chunk
+   * @return ChunkedBody
+   */
+  public ChunkedBody appendChunk(final byte[] chunk) throws UnsupportedOperationException {
+    throw new UnsupportedOperationException("Adding chunks in the form of byte[] is not yet supported");
+  }
+
+  /**
    * Answer a new {@code Body} as a {@code PlainBody} with my content.
    * @return Body
    */
@@ -55,6 +64,11 @@ public class ChunkedBody implements Body {
   @Override
   public String content() {
     return toString();
+  }
+
+  @Override
+  public byte[] binaryContent() {
+    return toString().getBytes();
   }
 
   /**

--- a/src/main/java/io/vlingo/http/PlainBody.java
+++ b/src/main/java/io/vlingo/http/PlainBody.java
@@ -20,6 +20,11 @@ public class PlainBody implements Body {
     return content;
   }
 
+  @Override
+  public byte[] binaryContent() {
+    return content.getBytes();
+  }
+
   /**
    * @see io.vlingo.http.Body#hasContent()
    */

--- a/src/main/java/io/vlingo/http/Response.java
+++ b/src/main/java/io/vlingo/http/Response.java
@@ -25,7 +25,15 @@ public class Response {
     return new Response(Version.Http1_1, statusCode, Headers.empty(), Body.from(entity));
   }
 
+  public static Response of(final Status statusCode, final byte[] entity) {
+    return new Response(Version.Http1_1, statusCode, Headers.empty(), Body.from(entity));
+  }
+
   public static Response of(final Version version, final Status statusCode, final String entity) {
+    return new Response(version, statusCode, Headers.empty(), Body.from(entity));
+  }
+
+  public static Response of(final Version version, final Status statusCode, final byte[] entity) {
     return new Response(version, statusCode, Headers.empty(), Body.from(entity));
   }
 
@@ -41,7 +49,15 @@ public class Response {
     return new Response(Version.Http1_1, statusCode, headers, Body.from(entity));
   }
 
+  public static Response of(final Status statusCode, final Headers<ResponseHeader> headers, final byte[] entity) {
+    return new Response(Version.Http1_1, statusCode, headers, Body.from(entity));
+  }
+
   public static Response of(final Version version, final Status statusCode, final Headers<ResponseHeader> headers, final String entity) {
+    return new Response(version, statusCode, headers, Body.from(entity));
+  }
+
+  public static Response of(final Version version, final Status statusCode, final Headers<ResponseHeader> headers, final byte[] entity) {
     return new Response(version, statusCode, headers, Body.from(entity));
   }
 

--- a/src/main/java/io/vlingo/http/Response.java
+++ b/src/main/java/io/vlingo/http/Response.java
@@ -61,6 +61,10 @@ public class Response {
     return new Response(version, statusCode, headers, Body.from(entity));
   }
 
+  public static Response of(final Status statusCode, final Body body) {
+    return new Response(Version.Http1_1, statusCode, Headers.empty(), body);
+  }
+
   public static Response of(final Status statusCode, final Headers<ResponseHeader> headers, final Body entity) {
     return new Response(Version.Http1_1, statusCode, headers, entity);
   }

--- a/src/test/java/io/vlingo/http/BodyTest.java
+++ b/src/test/java/io/vlingo/http/BodyTest.java
@@ -138,4 +138,16 @@ public class BodyTest {
     assertTrue(body.hasContent());
     assertTrue(body.content().startsWith("%PDF"));
   }
+
+  @Test
+  public void testThatBinaryBodyIsNotEncoded() {
+    final byte[] pdfBytes = { 37, 80, 68, 70, 45, 49, 46, 52, 10, 37, -30, -29, -49, -45, 10, 49 };
+
+    final Body body = Body.from(pdfBytes, Body.Encoding.None);
+
+    assertNotNull(body);
+    assertNotNull(body.content());
+    assertTrue(body.hasContent());
+    assertEquals(body.binaryContent(),pdfBytes);
+  }
 }

--- a/src/test/java/io/vlingo/http/ResponseTest.java
+++ b/src/test/java/io/vlingo/http/ResponseTest.java
@@ -8,10 +8,8 @@
 package io.vlingo.http;
 
 import static io.vlingo.http.Response.Status.Ok;
-import static io.vlingo.http.ResponseHeader.CacheControl;
-import static io.vlingo.http.ResponseHeader.ETag;
-import static io.vlingo.http.ResponseHeader.headers;
-import static io.vlingo.http.ResponseHeader.of;
+import static io.vlingo.http.ResponseHeader.*;
+import static io.vlingo.http.ResponseHeader.ContentLength;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -35,6 +33,19 @@ public class ResponseTest {
     final String facsimile = "HTTP/1.1 200 OK\nCache-Control: max-age=3600\nContent-Length: " + body.length() + "\n\n{ text : \"some text\" }";
 
     assertEquals(facsimile, response.toString());
+  }
+
+  @Test
+  public void testBinaryBodyResponseWithOneHeaderAndEntity() {
+    final byte[] body = { 1, 2, 1, 2 };
+    final Response response = Response.of(Version.Http1_1, Ok,
+      Header.Headers.of(
+        ResponseHeader.of(ContentType, "application/octet-stream"),
+        ResponseHeader.of(ContentLength, Integer.toString(body.length))
+      ), Body.from(body, Body.Encoding.None));
+
+
+    assertEquals(body, response.entity.binaryContent());
   }
 
   @Test

--- a/src/test/java/io/vlingo/http/resource/RequestHandler0Test.java
+++ b/src/test/java/io/vlingo/http/resource/RequestHandler0Test.java
@@ -9,31 +9,21 @@
 
 package io.vlingo.http.resource;
 
-import static io.vlingo.common.Completes.withSuccess;
-import static io.vlingo.http.Response.of;
-import static io.vlingo.http.Response.Status.Created;
-import static io.vlingo.http.resource.ParameterResolver.body;
-import static io.vlingo.http.resource.ParameterResolver.header;
-import static io.vlingo.http.resource.ParameterResolver.path;
-import static io.vlingo.http.resource.ParameterResolver.query;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import java.net.URI;
-import java.util.Collections;
-
+import io.vlingo.http.*;
+import io.vlingo.http.sample.user.NameData;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import io.vlingo.http.Body;
-import io.vlingo.http.Header;
-import io.vlingo.http.Method;
-import io.vlingo.http.Request;
-import io.vlingo.http.RequestHeader;
-import io.vlingo.http.Response;
-import io.vlingo.http.Version;
-import io.vlingo.http.sample.user.NameData;
+import java.net.URI;
+import java.util.Collections;
+
+import static io.vlingo.common.Completes.withSuccess;
+import static io.vlingo.http.Response.Status.Created;
+import static io.vlingo.http.Response.of;
+import static io.vlingo.http.resource.ParameterResolver.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class RequestHandler0Test extends RequestHandlerTestBase {
 
@@ -50,6 +40,19 @@ public class RequestHandler0Test extends RequestHandlerTestBase {
     assertEquals(Method.GET, handler.method);
     assertEquals("/helloworld", handler.path);
     assertResponsesAreEquals(of(Created), response);
+  }
+
+  @Test
+  public void simpleHandlerWithBinaryResponse() {
+    byte[] body = {1, 2, 1, 2};
+    final RequestHandler0 handler = new RequestHandler0(Method.GET, "/helloworld")
+      .handle(() -> withSuccess(Response.of(Created, Body.from(body, Body.Encoding.None))));
+    final Response response = handler.execute(Request.method(Method.GET), logger).outcome();
+
+    assertNotNull(handler);
+    assertEquals(Method.GET, handler.method);
+    assertEquals("/helloworld", handler.path);
+    assertEquals(Body.from(body, Body.Encoding.None).binaryContent(), response.entity.binaryContent());
   }
 
   @Test()
@@ -124,12 +127,12 @@ public class RequestHandler0Test extends RequestHandlerTestBase {
   }
 
   @Test
-  @SuppressWarnings( "deprecation" )
+  @SuppressWarnings("deprecation")
   public void addingHandlerBodyWithMapper() {
     final Request request = Request.has(Method.POST)
-                                   .and(URI.create("/user/admin/name"))
-                                   .and(Body.from("{\"given\":\"John\",\"family\":\"Doe\"}"))
-                                   .and(Version.Http1_1);
+      .and(URI.create("/user/admin/name"))
+      .and(Body.from("{\"given\":\"John\",\"family\":\"Doe\"}"))
+      .and(Version.Http1_1);
     final Action.MappedParameters mappedParameters =
       new Action.MappedParameters(1, Method.POST, "ignored", Collections.singletonList(
         new Action.MappedParameter("String", "admin"))
@@ -146,10 +149,10 @@ public class RequestHandler0Test extends RequestHandlerTestBase {
   @Test
   public void addingHandlerBodyWithMediaTypeMapper() {
     final Request request = Request.has(Method.POST)
-                                   .and(URI.create("/user/admin/name"))
-                                   .and(Body.from("{\"given\":\"John\",\"family\":\"Doe\"}"))
-                                   .and(RequestHeader.of(RequestHeader.ContentType, "application/json"))
-                                   .and(Version.Http1_1);
+      .and(URI.create("/user/admin/name"))
+      .and(Body.from("{\"given\":\"John\",\"family\":\"Doe\"}"))
+      .and(RequestHeader.of(RequestHeader.ContentType, "application/json"))
+      .and(Version.Http1_1);
     final Action.MappedParameters mappedParameters =
       new Action.MappedParameters(1, Method.POST, "ignored", Collections.singletonList(
         new Action.MappedParameter("String", "admin"))


### PR DESCRIPTION
Closes #35.

This adds the ability to put `byte[]`s into a `Body` and retrieve it.

Actually, I am not really happy with the implementation but can't think of anything that wouldn't break existing APIs.
Now all `Body` implementations can return their content as `byte[]` (`binaryContent()`) which does not hurt and as String (`content()`) - which could make no sense for binary data at all.

Perhaps it can serve as a starting point, though.

⚠️ Chunked `byte[]` responses are not yet supported, as the underlying content is also `String`. 

IMHO, we should rather base the content of `Body` on a `byte[]` and apply the encodings on that. That would get rid of the `contents()` and `binaryContents()` redundancy.

