### PR TITLE
[WIP] Fix route matching for similar routes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,10 +93,23 @@
     </plugins>
   </build>
   <dependencies>
+    <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>1.21</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>1.21</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -105,6 +118,8 @@
       <version>1.0.13</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- vlingo/PLATFORM dependencies -->
     <dependency>
       <groupId>io.vlingo</groupId>
       <artifactId>vlingo-common</artifactId>

--- a/src/main/java/io/vlingo/http/resource/Action.java
+++ b/src/main/java/io/vlingo/http/resource/Action.java
@@ -17,10 +17,9 @@ import io.vlingo.http.Method;
 import io.vlingo.http.Request;
 
 public final class Action {
-  static final MatchResults unmatchedResults = new MatchResults(null, null, Collections.emptyList(), "", false);
+  static final MatchResults unmatchedResults = new MatchResults(null, null, Collections.emptyList(), "");
 
   public final List<MappedParameter> additionalParameters;
-  public final boolean disallowPathParametersWithSlash;
   public final int id;
   public final Method method;
   public final String uri;
@@ -29,18 +28,17 @@ public final class Action {
   public final Mapper mapper;
   private final Matchable matchable;
 
-  public Action(final int id, final String method, final String uri, final String to, final String mapper, final boolean disallowPathParametersWithSlash) {
-    this(id, method, uri, to, mapper, disallowPathParametersWithSlash, Collections.emptyList());
+  public Action(final int id, final String method, final String uri, final String to, final String mapper) {
+    this(id, method, uri, to, mapper, Collections.emptyList());
   }
 
-  public Action(final int id, final String method, final String uri, final String to, final String mapper, final boolean disallowPathParametersWithSlash, final List<MappedParameter> additionalParameters) {
+  public Action(final int id, final String method, final String uri, final String to, final String mapper, final List<MappedParameter> additionalParameters) {
     this.id = id;
     this.method = Method.from(method);
     this.uri = uri;
     this.to = new ToSpec(to);
     this.originalTo = to;
     this.mapper = mapper == null ? DefaultJsonMapper.instance : mapperFrom(mapper);
-    this.disallowPathParametersWithSlash = disallowPathParametersWithSlash;
     this.additionalParameters = additionalParameters;
     this.matchable = new Matchable(uri);
   }
@@ -93,11 +91,11 @@ public final class Action {
       }
       int nextPathSegmentIndex = indexOfNextSegmentStart(pathCurrentIndex, path);
       if ( nextPathSegmentIndex != path.length()) {
-        if (disallowPathParametersWithSlash || nextPathSegmentIndex < path.length() - 1) {
+        if (nextPathSegmentIndex < path.length() - 1) {
           return unmatchedResults;
         }
       }
-      final MatchResults matchResults = new MatchResults(this, running, parameterNames(), path, disallowPathParametersWithSlash);
+      final MatchResults matchResults = new MatchResults(this, running, parameterNames(), path);
       return matchResults;
     }
     return unmatchedResults;
@@ -253,8 +251,7 @@ public final class Action {
             final Action action,
             final RunningMatchSegments running,
             final List<String> parameterNames,
-            final String path,
-            final boolean disallowPathParametersWithSlash) {
+            final String path) {
 
       this.action = action;
       this.parameters = new ArrayList<>(parameterNames.size());
@@ -275,7 +272,7 @@ public final class Action {
               return;
             }
             final String value = path.substring(pathStartIndex, pathEndIndex);
-            if (disallowPathParametersWithSlash && value.indexOf("/") >= 0) {
+            if (value.indexOf("/") >= 0) {
               this.matched = false;
               return;
             }

--- a/src/main/java/io/vlingo/http/resource/Action.java
+++ b/src/main/java/io/vlingo/http/resource/Action.java
@@ -7,21 +7,17 @@
 
 package io.vlingo.http.resource;
 
-import io.vlingo.common.Tuple2;
-import io.vlingo.http.Method;
-import io.vlingo.http.Request;
-
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public final class Action {
-  static final String PATH_SEPARATOR = "/";
-  static final String PATH_PARAM_PREFIX = "{";
-  static final String PATH_PARAM_SUFFIX = "}";
+import io.vlingo.common.Tuple2;
+import io.vlingo.http.Method;
+import io.vlingo.http.Request;
 
-  static final MatchResults unmatchedResults = new MatchResults(null, null, Collections.emptyList(), new String[]{});
+public final class Action {
+  static final MatchResults unmatchedResults = new MatchResults(null, null, Collections.emptyList(), "");
 
   public final List<MappedParameter> additionalParameters;
   public final int id;
@@ -64,55 +60,45 @@ public final class Action {
     return new MappedParameters(this.id, this.method, to.methodName, mapped);
   }
 
+  private int indexOfNextSegmentStart(int currentIndex, String path) {
+    int nextSegmentStart = path.indexOf("/", currentIndex);
+    if (nextSegmentStart < currentIndex) {
+      return path.length();
+    }
+    return nextSegmentStart;
+  }
+
   MatchResults matchWith(final Method method, final URI uri) {
     if (this.method.equals(method)) {
-      final String path =
-        uri.getPath();
-      final String[] pathSegments = splitUri(path, matchable.totalSegments());
-
-      final PathSegment[] templateSegments = new PathSegment[matchable.totalSegments()];
-      final RunningMatchSegments running = new RunningMatchSegments(matchable.totalSegments());
-
-      if (pathSegments.length != templateSegments.length) {
-        return unmatchedResults;
-      }
-
-      matchable.pathSegments.toArray(templateSegments);
-      for (int position = 0; position < templateSegments.length; position++) {
-        final PathSegment templateSegment = matchable.pathSegment(position);
-        if (!templateSegment.isPathParameter()) {
-          if (!templateSegment.value.equals(pathSegments[position]))
-            return unmatchedResults;
-          running.keepPathSegment(position);
-          // continue only if we have a matching static path segment
+      final String path = uri.getPath();
+      int pathCurrentIndex = 0;
+      final int totalSegments = matchable.totalSegments();
+      final RunningMatchSegments running = new RunningMatchSegments(totalSegments);
+      for (int idx = 0; idx < totalSegments; ++idx) {
+        final PathSegment segment = matchable.pathSegment(idx);
+        if (segment.isPathParameter()) {
+          running.keepParameterSegment(pathCurrentIndex);
+          pathCurrentIndex = indexOfNextSegmentStart(pathCurrentIndex, path);
         } else {
-          running.keepParameterSegment(position);
+          final int indexOfSegment = path.indexOf(segment.value, pathCurrentIndex);
+          if (indexOfSegment == -1 || (pathCurrentIndex == 0 && indexOfSegment != 0)) {
+            return unmatchedResults;
+          }
+          final int lastIndex = segment.lastIndexOf(indexOfSegment);
+          running.keepPathSegment(indexOfSegment, lastIndex);
+          pathCurrentIndex = lastIndex;
         }
       }
-      return new MatchResults(this, running, parameterNames(), pathSegments);
+      int nextPathSegmentIndex = indexOfNextSegmentStart(pathCurrentIndex, path);
+      if ( nextPathSegmentIndex != path.length()) {
+        if (nextPathSegmentIndex < path.length() - 1) {
+          return unmatchedResults;
+        }
+      }
+      final MatchResults matchResults = new MatchResults(this, running, parameterNames(), path);
+      return matchResults;
     }
     return unmatchedResults;
-  }
-
-  private static String[] splitUri(String uri) {
-    return splitUri(uri, 10);
-  }
-  private static String[] splitUri(String uri, int expectedSize) {
-    List<String> segments = new ArrayList<>(expectedSize);
-    int pos = 0;
-    int idx;
-    while (true) {
-      idx = uri.indexOf(PATH_SEPARATOR, pos);
-      if (idx < 0) {
-        segments.add(uri.substring(pos));
-        break;
-      }
-      segments.add(uri.substring(pos, idx));
-      pos = idx + 1;
-    }
-
-    String[] result = new String[segments.size()];
-    return segments.toArray(result);
   }
 
   @Override
@@ -168,34 +154,34 @@ public final class Action {
     final String type = this.to.parameterOf(parameter.name).type;
 
     switch (type) {
-      case "String":
-        return parameter.value;
-      case "int":
-      case "Integer":
-        return Integer.parseInt(parameter.value);
-      case "long":
-      case "Long":
-        return Long.parseLong(parameter.value);
-      case "boolean":
-      case "Boolean":
-        return Boolean.parseBoolean(parameter.value);
-      case "double":
-      case "Double":
-        return Double.parseDouble(parameter.value);
-      case "short":
-      case "Short":
-        return Short.parseShort(parameter.value);
-      case "float":
-      case "Float":
-        return Float.parseFloat(parameter.value);
-      case "char":
-      case "Character":
-        return parameter.value.charAt(0);
-      case "byte":
-      case "Byte":
-        return Byte.parseByte(parameter.value);
-      default:
-        return null;
+    case "String":
+      return parameter.value;
+    case "int":
+    case "Integer":
+      return Integer.parseInt(parameter.value);
+    case "long":
+    case "Long":
+      return Long.parseLong(parameter.value);
+    case "boolean":
+    case "Boolean":
+      return Boolean.parseBoolean(parameter.value);
+    case "double":
+    case "Double":
+      return Double.parseDouble(parameter.value);
+    case "short":
+    case "Short":
+      return Short.parseShort(parameter.value);
+    case "float":
+    case "Float":
+      return Float.parseFloat(parameter.value);
+    case "char":
+    case "Character":
+      return parameter.value.charAt(0);
+    case "byte":
+    case "Byte":
+      return Byte.parseByte(parameter.value);
+    default:
+      return null;
     }
   }
 
@@ -262,10 +248,10 @@ public final class Action {
     }
 
     MatchResults(
-      final Action action,
-      final RunningMatchSegments running,
-      final List<String> parameterNames,
-      final String[] pathSegments) {
+            final Action action,
+            final RunningMatchSegments running,
+            final List<String> parameterNames,
+            final String path) {
 
       this.action = action;
       this.parameters = new ArrayList<>(parameterNames.size());
@@ -273,18 +259,30 @@ public final class Action {
       if (running == null) {
         this.matched = false;
       } else {
+        int pathLength = 0;
         final int total = running.total();
-        int staticPathSegments = 0;
-        for (int position = 0, parameterIndex = 0; position < total; ++position) {
-          final MatchSegment segment = running.matchSegment(position);
+        for (int idx = 0, parameterIndex = 0; idx < total; ++idx) {
+          final MatchSegment segment = running.matchSegment(idx);
 
           if (segment.isPathParameter()) {
-            parameters.add(new RawPathParameter(parameterNames.get(parameterIndex++), pathSegments[position]));
+            final int pathStartIndex = segment.pathStartIndex();
+            final int pathEndIndex = running.nextSegmentStartIndex(idx, path.length());
+            if (pathStartIndex >= pathEndIndex) {
+              this.matched = false;
+              return;
+            }
+            final String value = path.substring(pathStartIndex, pathEndIndex);
+            if (value.indexOf("/") >= 0) {
+              this.matched = false;
+              return;
+            }
+            pathLength += value.length();
+            parameters.add(new RawPathParameter(parameterNames.get(parameterIndex++), value));
           } else {
-            staticPathSegments++;
+            pathLength += action.matchable.pathSegment(idx).value.length();
           }
         }
-        this.matched = parameters.size() + staticPathSegments == pathSegments.length;
+        this.matched = pathLength == path.length();
       }
     }
 
@@ -393,14 +391,17 @@ public final class Action {
       this.matchSegments = new ArrayList<>(totalSegments + 1);
     }
 
-    void keepParameterSegment(final int position) {
-      matchSegments.add(new MatchSegment(true, position));
+    void keepParameterSegment(final int pathStartIndex) {
+      matchSegments.add(new MatchSegment(true, pathStartIndex));
     }
 
-    void keepPathSegment(final int position) {
-      matchSegments.add(new MatchSegment(false, position));
+    void keepPathSegment(final int pathStartIndex, final int pathEndIndex) {
+      matchSegments.add(new MatchSegment(false, pathStartIndex));
     }
 
+    int nextSegmentStartIndex(final int index, final int maxIndex) {
+      return index < (total() - 1) ? matchSegment(index + 1).pathStartIndex : maxIndex;
+    }
 
     MatchSegment matchSegment(final int index) {
       return matchSegments.get(index);
@@ -417,20 +418,20 @@ public final class Action {
 
   private static class MatchSegment {
     private final boolean pathParameter;
-    private final int position;
+    private final int pathStartIndex;
 
     @Override
     public String toString() {
-      return "MatchSegment[pathParameter=" + pathParameter + ", position=" + position + "]";
+      return "MatchSegment[pathParameter=" + pathParameter + ", pathStartIndex=" + pathStartIndex + "]";
     }
 
-    MatchSegment(final boolean pathParameter, final int position) {
+    MatchSegment(final boolean pathParameter, final int pathStartIndex) {
       this.pathParameter = pathParameter;
-      this.position = position;
+      this.pathStartIndex = pathStartIndex;
     }
 
-    int position() {
-      return position;
+    int pathStartIndex() {
+      return pathStartIndex;
     }
 
     boolean isPathParameter() {
@@ -469,17 +470,26 @@ public final class Action {
 
     private List<PathSegment> segmented(final String uri) {
       final List<PathSegment> segments = new ArrayList<>();
-      for (String segment : splitUri(uri)) {
-        if (segment.startsWith(PATH_PARAM_PREFIX)) {
-          if (!segment.endsWith(PATH_PARAM_SUFFIX)) {
-            throw new IllegalStateException("URI template has unbalanced brace: " + uri);
+      String start = uri;
+      while (true) {
+        final int openBrace = start.indexOf("{");
+        if (openBrace >= 0) {
+          final int closeBrace = start.indexOf("}", openBrace);
+          if (closeBrace > openBrace) {
+            final String segment = start.substring(0, openBrace);
+            segments.add(new PathSegment(segment, false));
+            final String parameter = start.substring(openBrace + 1, closeBrace);
+            segments.add(new PathSegment(parameter, true));
+            start = start.substring(closeBrace + 1);
+            if (start.isEmpty()) {
+              break;
+            }
+          } else {
+            throw new IllegalStateException("URI has unbalanced brace: " + uri);
           }
-          segments.add(
-            new PathSegment(
-              segment.substring(1, segment.length() - 1),
-              true));
         } else {
-          segments.add(new PathSegment(segment, false));
+          segments.add(new PathSegment(start, false));
+          break;
         }
       }
 

--- a/src/main/java/io/vlingo/http/resource/Action.java
+++ b/src/main/java/io/vlingo/http/resource/Action.java
@@ -168,34 +168,34 @@ public final class Action {
     final String type = this.to.parameterOf(parameter.name).type;
 
     switch (type) {
-      case "String":
-        return parameter.value;
-      case "int":
-      case "Integer":
-        return Integer.parseInt(parameter.value);
-      case "long":
-      case "Long":
-        return Long.parseLong(parameter.value);
-      case "boolean":
-      case "Boolean":
-        return Boolean.parseBoolean(parameter.value);
-      case "double":
-      case "Double":
-        return Double.parseDouble(parameter.value);
-      case "short":
-      case "Short":
-        return Short.parseShort(parameter.value);
-      case "float":
-      case "Float":
-        return Float.parseFloat(parameter.value);
-      case "char":
-      case "Character":
-        return parameter.value.charAt(0);
-      case "byte":
-      case "Byte":
-        return Byte.parseByte(parameter.value);
-      default:
-        return null;
+    case "String":
+      return parameter.value;
+    case "int":
+    case "Integer":
+      return Integer.parseInt(parameter.value);
+    case "long":
+    case "Long":
+      return Long.parseLong(parameter.value);
+    case "boolean":
+    case "Boolean":
+      return Boolean.parseBoolean(parameter.value);
+    case "double":
+    case "Double":
+      return Double.parseDouble(parameter.value);
+    case "short":
+    case "Short":
+      return Short.parseShort(parameter.value);
+    case "float":
+    case "Float":
+      return Float.parseFloat(parameter.value);
+    case "char":
+    case "Character":
+      return parameter.value.charAt(0);
+    case "byte":
+    case "Byte":
+      return Byte.parseByte(parameter.value);
+    default:
+      return null;
     }
   }
 

--- a/src/main/java/io/vlingo/http/resource/Action.java
+++ b/src/main/java/io/vlingo/http/resource/Action.java
@@ -272,7 +272,7 @@ public final class Action {
               return;
             }
             final String value = path.substring(pathStartIndex, pathEndIndex);
-            if (value.indexOf("/") >= 0) {
+            if (value.indexOf("/") >= 0 && !"/".equals(path.substring(pathEndIndex-1))) {
               this.matched = false;
               return;
             }

--- a/src/main/java/io/vlingo/http/resource/Action.java
+++ b/src/main/java/io/vlingo/http/resource/Action.java
@@ -168,34 +168,34 @@ public final class Action {
     final String type = this.to.parameterOf(parameter.name).type;
 
     switch (type) {
-    case "String":
-      return parameter.value;
-    case "int":
-    case "Integer":
-      return Integer.parseInt(parameter.value);
-    case "long":
-    case "Long":
-      return Long.parseLong(parameter.value);
-    case "boolean":
-    case "Boolean":
-      return Boolean.parseBoolean(parameter.value);
-    case "double":
-    case "Double":
-      return Double.parseDouble(parameter.value);
-    case "short":
-    case "Short":
-      return Short.parseShort(parameter.value);
-    case "float":
-    case "Float":
-      return Float.parseFloat(parameter.value);
-    case "char":
-    case "Character":
-      return parameter.value.charAt(0);
-    case "byte":
-    case "Byte":
-      return Byte.parseByte(parameter.value);
-    default:
-      return null;
+      case "String":
+        return parameter.value;
+      case "int":
+      case "Integer":
+        return Integer.parseInt(parameter.value);
+      case "long":
+      case "Long":
+        return Long.parseLong(parameter.value);
+      case "boolean":
+      case "Boolean":
+        return Boolean.parseBoolean(parameter.value);
+      case "double":
+      case "Double":
+        return Double.parseDouble(parameter.value);
+      case "short":
+      case "Short":
+        return Short.parseShort(parameter.value);
+      case "float":
+      case "Float":
+        return Float.parseFloat(parameter.value);
+      case "char":
+      case "Character":
+        return parameter.value.charAt(0);
+      case "byte":
+      case "Byte":
+        return Byte.parseByte(parameter.value);
+      default:
+        return null;
     }
   }
 

--- a/src/main/java/io/vlingo/http/resource/Actions.java
+++ b/src/main/java/io/vlingo/http/resource/Actions.java
@@ -15,21 +15,21 @@ public class Actions {
   private int currentId;
   private final List<Action> actions;
 
-  public static Actions canBe(final String method, final String uri, final String to, final boolean disallowPathParametersWithSlash) {
-    return new Actions(method, uri, to, null, disallowPathParametersWithSlash);
+  public static Actions canBe(final String method, final String uri, final String to) {
+    return new Actions(method, uri, to, null);
   }
 
-  public static Actions canBe(final String method, final String uri, final String to, final String mapper, final boolean disallowPathParametersWithSlash) {
-    return new Actions(method, uri, to, mapper, disallowPathParametersWithSlash);
+  public static Actions canBe(final String method, final String uri, final String to, final String mapper) {
+    return new Actions(method, uri, to, mapper);
   }
 
-  public Actions also(final String method, final String uri, final String to, final boolean disallowPathParametersWithSlash) {
-    actions.add(new Action(currentId++, method, uri, to, null, disallowPathParametersWithSlash));
+  public Actions also(final String method, final String uri, final String to) {
+    actions.add(new Action(currentId++, method, uri, to, null));
     return this;
   }
 
-  public Actions also(final String method, final String uri, final String to, final String mapper, final boolean disallowPathParametersWithSlash) {
-    actions.add(new Action(currentId++, method, uri, to, mapper, disallowPathParametersWithSlash));
+  public Actions also(final String method, final String uri, final String to, final String mapper) {
+    actions.add(new Action(currentId++, method, uri, to, mapper));
     return this;
   }
 
@@ -37,8 +37,8 @@ public class Actions {
     return Collections.unmodifiableList(actions);
   }
 
-  private Actions(final String method, final String uri, final String to, final String mapper, final boolean disallowPathParametersWithSlash) {
+  private Actions(final String method, final String uri, final String to, final String mapper) {
     this.actions = new ArrayList<>();
-    actions.add(new Action(currentId++, method, uri, to, mapper, disallowPathParametersWithSlash));
+    actions.add(new Action(currentId++, method, uri, to, mapper));
   }
 }

--- a/src/main/java/io/vlingo/http/resource/DynamicResource.java
+++ b/src/main/java/io/vlingo/http/resource/DynamicResource.java
@@ -32,8 +32,7 @@ public class DynamicResource extends Resource<ResourceHandler> {
         predicate.method.toString(),
         predicate.path,
         "dynamic" + currentId + "(" + predicate.actionSignature + ")",
-        null,
-        false));
+        null));
     }
   }
 

--- a/src/main/java/io/vlingo/http/resource/Loader.java
+++ b/src/main/java/io/vlingo/http/resource/Loader.java
@@ -139,7 +139,7 @@ public class Loader {
 
         final List<Action> actions = new ArrayList<>(1);
         final List<MappedParameter> additionalParameters = Arrays.asList(mappedParameterProducerClass, mappedParameterProductElements);
-        actions.add(new Action(0, Method.GET.name, feedRequestURI, feedProducerFeed, null, true, additionalParameters));
+        actions.add(new Action(0, Method.GET.name, feedRequestURI, feedProducerFeed, null, additionalParameters));
         final ConfigurationResource<?> resource = resourceFor(resourceName, FeedResource.class, handlerPoolSize, actions);
         feedResourceActions.put(resourceName, resource);
       } catch (Exception e) {
@@ -184,8 +184,8 @@ public class Loader {
 
         final List<Action> actions = new ArrayList<>(2);
         final List<MappedParameter> additionalParameters = Arrays.asList(mappedParameterClass, mappedParameterPayload, mappedParameterInterval, mappedParameterDefaultId);
-        actions.add(new Action(0, Method.GET.name, subscribeURI, ssePublisherSubscribeTo, null, true, additionalParameters));
-        actions.add(new Action(1, Method.DELETE.name, unsubscribeURI, ssePublisherUnsubscribeTo, null, true));
+        actions.add(new Action(0, Method.GET.name, subscribeURI, ssePublisherSubscribeTo, null, additionalParameters));
+        actions.add(new Action(1, Method.DELETE.name, unsubscribeURI, ssePublisherUnsubscribeTo, null));
         final ConfigurationResource<?> resource = resourceFor(resourceName, SseStreamResource.class, handlerPoolSize, actions);
         sseResourceActions.put(resourceName, resource);
       } catch (Exception e) {
@@ -229,7 +229,7 @@ public class Loader {
 
         final List<Action> actions = new ArrayList<>(1);
         final List<MappedParameter> additionalParameters = Arrays.asList(mappedParameterRoot, mappedParameterValidSubPaths);
-        actions.add(new Action(0, Method.GET.name, actionSubPath + slash + staticFilesResourcePathParameter, staticFilesResourceServeFile, null, false, additionalParameters));
+        actions.add(new Action(0, Method.GET.name, actionSubPath + slash + staticFilesResourcePathParameter, staticFilesResourceServeFile, null, additionalParameters));
         final ConfigurationResource<?> resource = resourceFor(resourceName, StaticFilesResource.class, Integer.parseInt(poolSize), actions);
         staticFilesResourceActions.put(resourceName, resource);
       }
@@ -289,7 +289,7 @@ public class Loader {
         final String to = properties.getProperty(keyPrefix + "to", null);
         final String mapper = properties.getProperty(keyPrefix + "mapper", null);
 
-        resourceActions.add(new Action(actionId, method, uri, to, mapper, disallowPathParametersWithSlash));
+        resourceActions.add(new Action(actionId, method, uri, to, mapper));
       } catch (Exception e) {
         System.out.println("vlingo/http: Failed to load resource: " + resourceName + " action:" + actionName + " because: " + e.getMessage());
         throw e;

--- a/src/test/java/io/vlingo/http/FiltersTest.java
+++ b/src/test/java/io/vlingo/http/FiltersTest.java
@@ -95,8 +95,8 @@ public class FiltersTest {
 
     Resource<?> resource =
             ConfigurationResource.defining("profile", ProfileResource.class, 5,
-              Actions.canBe("PUT", "/users/{userId}/profile", "define(String userId, body:io.vlingo.http.sample.user.ProfileData profileData)", "io.vlingo.http.sample.user.ProfileDataMapper", false)
-                      .also("GET", "/users/{userId}/profile", "query(String userId)", "io.vlingo.http.sample.user.ProfileDataMapper", false)
+              Actions.canBe("PUT", "/users/{userId}/profile", "define(String userId, body:io.vlingo.http.sample.user.ProfileData profileData)", "io.vlingo.http.sample.user.ProfileDataMapper")
+                      .also("GET", "/users/{userId}/profile", "query(String userId)", "io.vlingo.http.sample.user.ProfileDataMapper")
                       .thatsAll());
 
     Server server =

--- a/src/test/java/io/vlingo/http/ToSpecParserTest.java
+++ b/src/test/java/io/vlingo/http/ToSpecParserTest.java
@@ -16,46 +16,46 @@ public class ToSpecParserTest {
 
   @Test
   public void testSimpleUnqualifiedNonBodyParameterMapping() {
-    new Action(0, "PATCH", "/airports/{airportId}/stringProperty", "changeStringProperty(String value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/integerProperty", "changeIntegerProperty(int value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/integerProperty", "changeIntegerProperty(Integer value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/longProperty", "changeLongProperty(long value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/longProperty", "changeLongProperty(Long value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/booleanProperty", "changeBooleanProperty(boolean value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/booleanProperty", "changeBooleanProperty(Long value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/doubleProperty", "changeDoubleProperty(double value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/doubleProperty", "changeDoubleProperty(Double value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/shortProperty", "changeShortProperty(short value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/shortProperty", "changeShortProperty(Short value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/floatProperty", "changeFloatProperty(float value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/floatProperty", "changeFloatProperty(Float value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/characterProperty", "changeCharacterProperty(char value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/characterProperty", "changeCharacterProperty(Character value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/byteProperty", "changeByteProperty(byte value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/byteProperty", "changeByteProperty(Byte value)", null, true);
+    new Action(0, "PATCH", "/airports/{airportId}/stringProperty", "changeStringProperty(String value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/integerProperty", "changeIntegerProperty(int value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/integerProperty", "changeIntegerProperty(Integer value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/longProperty", "changeLongProperty(long value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/longProperty", "changeLongProperty(Long value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/booleanProperty", "changeBooleanProperty(boolean value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/booleanProperty", "changeBooleanProperty(Long value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/doubleProperty", "changeDoubleProperty(double value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/doubleProperty", "changeDoubleProperty(Double value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/shortProperty", "changeShortProperty(short value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/shortProperty", "changeShortProperty(Short value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/floatProperty", "changeFloatProperty(float value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/floatProperty", "changeFloatProperty(Float value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/characterProperty", "changeCharacterProperty(char value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/characterProperty", "changeCharacterProperty(Character value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/byteProperty", "changeByteProperty(byte value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/byteProperty", "changeByteProperty(Byte value)", null);
   }
   
   @Test(expected=IllegalStateException.class)
   public void testComplexUnqualifiedNonBodyParameterMapping() {
-    new Action(0, "PATCH", "/airports/{airportId}/geocode", "name(body:Geocode geocode)", null, true);
+    new Action(0, "PATCH", "/airports/{airportId}/geocode", "name(body:Geocode geocode)", null);
   }
 
   @Test
   public void testSimpleQualifiedBodyParameterMapping() {
-    new Action(0, "PATCH", "/airports/{airportId}/stringProperty", "changeStringProperty(body:java.lang.String value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/integerProperty", "changeIntegerProperty(body:java.lang.Integer value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/longProperty", "changeLongProperty(body:java.lang.Long value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/booleanProperty", "changeBooleanProperty(body:java.lang.Long value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/doubleProperty", "changeDoubleProperty(body:java.lang.Double value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/shortProperty", "changeShortProperty(body:java.lang.Short value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/floatProperty", "changeFloatProperty(body:java.lang.Float value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/characterProperty", "changeCharacterProperty(body:java.lang.Character value)", null, true);
-    new Action(0, "PATCH", "/airports/{airportId}/byteProperty", "changeByteProperty(body:java.lang.Byte value)", null, true);
+    new Action(0, "PATCH", "/airports/{airportId}/stringProperty", "changeStringProperty(body:java.lang.String value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/integerProperty", "changeIntegerProperty(body:java.lang.Integer value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/longProperty", "changeLongProperty(body:java.lang.Long value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/booleanProperty", "changeBooleanProperty(body:java.lang.Long value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/doubleProperty", "changeDoubleProperty(body:java.lang.Double value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/shortProperty", "changeShortProperty(body:java.lang.Short value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/floatProperty", "changeFloatProperty(body:java.lang.Float value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/characterProperty", "changeCharacterProperty(body:java.lang.Character value)", null);
+    new Action(0, "PATCH", "/airports/{airportId}/byteProperty", "changeByteProperty(body:java.lang.Byte value)", null);
   }
   
   @Test
   public void testComplexQualifiedBodyParameterMapping() {
-    new Action(0, "PATCH", "/airports/{airportId}/geocode", "name(body:io.vlingo.http.ToSpecParserTest$Geocode geocode)", null, true);
+    new Action(0, "PATCH", "/airports/{airportId}/geocode", "name(body:io.vlingo.http.ToSpecParserTest$Geocode geocode)", null);
   }
 
   class Geocode {

--- a/src/test/java/io/vlingo/http/resource/ActionTest.java
+++ b/src/test/java/io/vlingo/http/resource/ActionTest.java
@@ -86,6 +86,39 @@ public class ActionTest {
   }
 
   @Test
+  public void testMatchesMultipleParametersWithSimilarUri() throws Exception {
+    final Action shortAction =
+      new Action(
+        0,
+        "GET",
+        "/o/{oId}/u/{uId}/foo",
+        "foo(String oId, String uId, String uId)",
+        null,
+        false);
+
+    final Action longAction =
+      new Action(
+        0,
+        "GET",
+        "/o/{oId}/u/{uId}/c/{cId}/foo",
+        "foo(String oId, String uId, String uId, String cId)",
+        null,
+        false);
+
+    final MatchResults matchResultsShortUriToShortAction = shortAction.matchWith(Method.GET, new URI("/o/1/u/2/foo"));
+    final MatchResults matchResultsLongUriToShortAction = shortAction.matchWith(Method.GET, new URI("/o/1/u/2/c/3/foo"));
+
+    final MatchResults matchResultsShortUriToLongAction = longAction.matchWith(Method.GET, new URI("/o/1/u/2/foo"));
+    final MatchResults matchResultsLongUriToLongAction = longAction.matchWith(Method.GET, new URI("/o/1/u/2/c/3/foo"));
+
+
+    assertTrue(matchResultsShortUriToShortAction.matched);
+    assertFalse(matchResultsLongUriToShortAction.matched);
+    assertFalse(matchResultsShortUriToLongAction.matched);
+    assertTrue(matchResultsLongUriToLongAction.matched);
+  }
+
+  @Test
   public void testMatchesOneParameterWithEndSlash() throws Exception {
     final Action action = new Action(0, "GET", "/users/{userId}/", "queryUser(String userId)", null, false);
     

--- a/src/test/java/io/vlingo/http/resource/ActionTest.java
+++ b/src/test/java/io/vlingo/http/resource/ActionTest.java
@@ -26,7 +26,7 @@ public class ActionTest {
 
   @Test
   public void testMatchesNoParameters() throws Exception {
-    final Action action = new Action(0, "GET", "/users", "queryUsers()", null, false);
+    final Action action = new Action(0, "GET", "/users", "queryUsers()", null);
     
     final MatchResults matchResults = action.matchWith(Method.GET, new URI("/users"));
     
@@ -37,7 +37,7 @@ public class ActionTest {
 
   @Test
   public void testMatchesOneParameterInBetween() throws Exception {
-    final Action action = new Action(0, "PATCH", "/users/{userId}/name", "changeName(String userId)", null, false);
+    final Action action = new Action(0, "PATCH", "/users/{userId}/name", "changeName(String userId)", null);
     
     final MatchResults matchResults = action.matchWith(Method.PATCH, new URI("/users/1234567/name"));
     
@@ -50,7 +50,7 @@ public class ActionTest {
 
   @Test
   public void testMatchesOneParameterLastPosition() throws Exception {
-    final Action action = new Action(0, "GET", "/users/{userId}", "queryUser(String userId)", null, false);
+    final Action action = new Action(0, "GET", "/users/{userId}", "queryUser(String userId)", null);
     
     final MatchResults matchResults = action.matchWith(Method.GET, new URI("/users/1234567"));
     
@@ -69,8 +69,7 @@ public class ActionTest {
                     "GET",
                     "/catalogs/{catalogId}/products/{productId}/details/{detailId}",
                     "queryCatalogProductDetails(String catalogId, String productId, String detailId)",
-                    null,
-                    false);
+                    null);
     
     final MatchResults matchResults = action.matchWith(Method.GET, new URI("/catalogs/123/products/4567/details/890"));
     
@@ -93,8 +92,7 @@ public class ActionTest {
         "GET",
         "/o/{oId}/u/{uId}/foo",
         "foo(String oId, String uId, String uId)",
-        null,
-        false);
+        null);
 
     final Action longAction =
       new Action(
@@ -102,8 +100,7 @@ public class ActionTest {
         "GET",
         "/o/{oId}/u/{uId}/c/{cId}/foo",
         "foo(String oId, String uId, String uId, String cId)",
-        null,
-        false);
+        null);
 
     final MatchResults matchResultsShortUriToShortAction = shortAction.matchWith(Method.GET, new URI("/o/1/u/2/foo"));
     final MatchResults matchResultsLongUriToShortAction = shortAction.matchWith(Method.GET, new URI("/o/1/u/2/c/3/foo"));
@@ -120,7 +117,7 @@ public class ActionTest {
 
   @Test
   public void testMatchesOneParameterWithEndSlash() throws Exception {
-    final Action action = new Action(0, "GET", "/users/{userId}/", "queryUser(String userId)", null, false);
+    final Action action = new Action(0, "GET", "/users/{userId}/", "queryUser(String userId)", null);
     
     final MatchResults matchResults = action.matchWith(Method.GET, new URI("/users/1234567/"));
     
@@ -139,8 +136,7 @@ public class ActionTest {
                     "GET",
                     "/users/{userId}/emailAddresses/{emailAddressId}/",
                     "queryUserEmailAddress(String userId, String emailAddressId)",
-                    null,
-                    false);
+                    null);
     
     final MatchResults matchResults = action.matchWith(Method.GET, new URI("/users/1234567/emailAddresses/890/"));
     
@@ -155,7 +151,7 @@ public class ActionTest {
 
   @Test
   public void testNoMatchMethod() throws Exception {
-    final Action action = new Action(0, "GET", "/users/all", "queryUsers()", null, false);
+    final Action action = new Action(0, "GET", "/users/all", "queryUsers()", null);
     
     final MatchResults matchResults = action.matchWith(Method.POST, new URI("/users"));
     
@@ -166,7 +162,7 @@ public class ActionTest {
 
   @Test
   public void testNoMatchNoParameters() throws Exception {
-    final Action action = new Action(0, "GET", "/users/all", "queryUsers()", null, false);
+    final Action action = new Action(0, "GET", "/users/all", "queryUsers()", null);
     
     final MatchResults matchResults = action.matchWith(Method.GET, new URI("/users/one"));
     
@@ -177,7 +173,7 @@ public class ActionTest {
 
   @Test
   public void testNoMatchGivenAdditionalElements() throws Exception {
-    final Action action = new Action(0, "GET", "/users/{id}", "queryUsers(String userId)", null, false);
+    final Action action = new Action(0, "GET", "/users/{id}", "queryUsers(String userId)", null);
 
     final MatchResults matchResults = action.matchWith(Method.GET, new URI("/users/1234/extra"));
 
@@ -188,7 +184,7 @@ public class ActionTest {
 
   @Test
   public void testNoMatchEmptyParam() throws Exception {
-    final Action action = new Action(0, "GET", "/users/{id}/data", "queryUserData(String userId)", null, true);
+    final Action action = new Action(0, "GET", "/users/{id}/data", "queryUserData(String userId)", null);
 
     final MatchResults matchResults = action.matchWith(Method.GET, new URI("/users//data"));
 
@@ -199,7 +195,7 @@ public class ActionTest {
 
   @Test
   public void testMatchEmptyParamGivenAllowsTrailingSlash() throws Exception {
-    final Action action = new Action(0, "GET", "/users/{id}", "queryUsers(String userId)", null, false);
+    final Action action = new Action(0, "GET", "/users/{id}", "queryUsers(String userId)", null);
 
     final MatchResults matchResults = action.matchWith(Method.GET, new URI("/users//"));
 
@@ -217,8 +213,7 @@ public class ActionTest {
                     "GET",
                     "/users/{userId}/emailAddresses/{emailAddressId}/",
                     "queryUserEmailAddress(String userId, String emailAddressId)",
-                    null,
-                    false);
+                    null);
     
     final MatchResults matchResults = action.matchWith(Method.GET, new URI("/users/1234567/emailAddresses/890"));
     
@@ -235,8 +230,7 @@ public class ActionTest {
                     "GET",
                     "/users/{userId}/emailAddresses/{emailAddressId}",
                     "queryUserEmailAddress(String userId, String emailAddressId)",
-                    null,
-                    false);
+                    null);
     
     final MatchResults matchResults = action.matchWith(Method.GET, new URI("/users/1234567/emailAddresses/890/"));
     
@@ -255,8 +249,7 @@ public class ActionTest {
                     "GET",
                     "/users/{userId}",
                     "queryUser(String userId)",
-                    null,
-                    false);
+                    null);
 
     final URI uri = new URI("/users/1234567?one=1.1&two=2.0&three=three*&three=3.3");
     final MatchResults matchResults = action.matchWith(Method.GET, uri);

--- a/src/test/java/io/vlingo/http/resource/BenchmarkTests.java
+++ b/src/test/java/io/vlingo/http/resource/BenchmarkTests.java
@@ -20,7 +20,7 @@ import static junit.framework.TestCase.assertTrue;
 public class BenchmarkTests {
   @Test
   public void launchBenchmark() throws Exception {
-    final double expectedMinUsPerOp = 370;
+    final double expectedMinUsPerOp = 570; // taken from a test on travis w/ the original matching code
 
     Options opt = new OptionsBuilder()
       .include(this.getClass().getName() + ".*")

--- a/src/test/java/io/vlingo/http/resource/BenchmarkTests.java
+++ b/src/test/java/io/vlingo/http/resource/BenchmarkTests.java
@@ -23,7 +23,7 @@ public class BenchmarkTests {
     final double expectedMinUsPerOp = 570;
 
     Options opt = new OptionsBuilder()
-      .include(this.getClass().getName() + ".*")
+      .include(this.getClass().getSimpleName() + "\\.benchmark.*")
       .mode(Mode.AverageTime)
       .timeUnit(TimeUnit.MICROSECONDS)
       .warmupTime(TimeValue.seconds(1))
@@ -75,8 +75,7 @@ public class BenchmarkTests {
   }
 
   @Benchmark
-  public void
-  benchmarkActionMatching(ActionMatchingBenchmarkState state, Blackhole bh) {
+  public void benchmarkActionMatching(ActionMatchingBenchmarkState state, Blackhole bh) {
     Map<URI, Action> subjects = state.subjects;
 
     for (Map.Entry<URI, Action> e : subjects.entrySet()) {

--- a/src/test/java/io/vlingo/http/resource/BenchmarkTests.java
+++ b/src/test/java/io/vlingo/http/resource/BenchmarkTests.java
@@ -1,5 +1,6 @@
 package io.vlingo.http.resource;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
@@ -19,8 +20,9 @@ import static junit.framework.TestCase.assertTrue;
 
 public class BenchmarkTests {
   @Test
+  @Ignore("Ignoring this test in favor of the existing jMeter tests, but keep it for local tests of future refactorings to action matching")
   public void launchBenchmark() throws Exception {
-    final double expectedMinUsPerOp = 570;
+    final double expectedMinUsPerOp = 350;
 
     Options opt = new OptionsBuilder()
       .include(this.getClass().getSimpleName() + "\\.benchmark.*")

--- a/src/test/java/io/vlingo/http/resource/BenchmarkTests.java
+++ b/src/test/java/io/vlingo/http/resource/BenchmarkTests.java
@@ -20,7 +20,7 @@ import static junit.framework.TestCase.assertTrue;
 public class BenchmarkTests {
   @Test
   public void launchBenchmark() throws Exception {
-    final double expectedMinUsPerOp = 570; // taken from a test on travis w/ the original matching code
+    final double expectedMinUsPerOp = 370;
 
     Options opt = new OptionsBuilder()
       .include(this.getClass().getName() + ".*")

--- a/src/test/java/io/vlingo/http/resource/BenchmarkTests.java
+++ b/src/test/java/io/vlingo/http/resource/BenchmarkTests.java
@@ -20,7 +20,7 @@ import static junit.framework.TestCase.assertTrue;
 public class BenchmarkTests {
   @Test
   public void launchBenchmark() throws Exception {
-    final double expectedMinUsPerOp = 370;
+    final double expectedMinUsPerOp = 570;
 
     Options opt = new OptionsBuilder()
       .include(this.getClass().getName() + ".*")

--- a/src/test/java/io/vlingo/http/resource/BenchmarkTests.java
+++ b/src/test/java/io/vlingo/http/resource/BenchmarkTests.java
@@ -1,0 +1,87 @@
+package io.vlingo.http.resource;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static junit.framework.TestCase.assertTrue;
+
+public class BenchmarkTests {
+  @Test
+  public void launchBenchmark() throws Exception {
+    final double expectedMinUsPerOp = 370;
+
+    Options opt = new OptionsBuilder()
+      .include(this.getClass().getName() + ".*")
+      .mode(Mode.AverageTime)
+      .timeUnit(TimeUnit.MICROSECONDS)
+      .warmupTime(TimeValue.seconds(1))
+      .warmupIterations(2)
+      .measurementTime(TimeValue.seconds(1))
+      .measurementIterations(2)
+      .threads(1)
+      .forks(1)
+      .shouldFailOnError(true)
+      .shouldDoGC(true)
+      .build();
+
+    RunResult result = new Runner(opt).runSingle();
+    double usPerOp = result.getPrimaryResult().getScore();
+    assertTrue("µs/matching operation = " + usPerOp + " is higher than " + expectedMinUsPerOp,
+      usPerOp < expectedMinUsPerOp);
+  }
+
+  @State(Scope.Thread)
+  public static class ActionMatchingBenchmarkState {
+    Map<URI, Action> subjects;
+
+    @Setup(Level.Trial)
+    public void
+    initialize() {
+      subjects = new HashMap<>();
+      for (int i = 0; i < 1000; i++)
+        subjects.put(
+          URI.create("/param1/" + UUID.randomUUID() + "/param2/" + UUID.randomUUID() + "/"),
+          new Action(
+            0,
+            "GET",
+            "/param1/{p1}/param2/{p2}/",
+            "foo(String p1, String p2)",
+            null)
+        );
+      subjects.put(
+        URI.create("/a/" + UUID.randomUUID() + "/b/" + UUID.randomUUID() + "/c/" + UUID.randomUUID() + "/d/" + UUID.randomUUID()
+          + "/e/" + UUID.randomUUID() + "/f/" + UUID.randomUUID() + "/g/" + UUID.randomUUID() + "/h/" + UUID.randomUUID()
+          + "/i/" + UUID.randomUUID() + "/j/" + UUID.randomUUID() + "/k/" + UUID.randomUUID() + "/l/" + UUID.randomUUID()),
+        new Action(
+          0,
+          "GET",
+          "/a/{a}/b/{b}/c/{c}/d/{d}/e/{e}/f/{f}/g/{g}/h/{h}/i/{i}/j/{j}/k/{k}/l/{l}",
+          "foo(String a, String b, String c, String d, String e, String f, String g, String h, String i, String j, String k, String l)",
+          null)
+      );
+    }
+  }
+
+  @Benchmark
+  public void
+  benchmarkActionMatching(ActionMatchingBenchmarkState state, Blackhole bh) {
+    Map<URI, Action> subjects = state.subjects;
+
+    for (Map.Entry<URI, Action> e : subjects.entrySet()) {
+      Action a = e.getValue();
+      bh.consume(a.matchWith(a.method, e.getKey()));
+    }
+  }
+}

--- a/src/test/java/io/vlingo/http/resource/ConfigurationResourceTest.java
+++ b/src/test/java/io/vlingo/http/resource/ConfigurationResourceTest.java
@@ -237,12 +237,12 @@ public class ConfigurationResourceTest extends ResourceTestFixtures {
   @Test
   public void testThatAllPoorlyOrderedActionHaveMatches() throws Exception {
     System.out.println("testThatAllPoorlyOrderedActionHaveMatches()");
-    actionPostUser = new Action(0, "POST", "/users", "register(body:io.vlingo.http.sample.user.UserData userData)", null, true);
-    actionPatchUserContact = new Action(1, "PATCH", "/users/{userId}/contact", "changeContact(String userId, body:io.vlingo.http.sample.user.ContactData contactData)", null, true);
-    actionPatchUserName = new Action(2, "PATCH", "/users/{userId}/name", "changeName(String userId, body:io.vlingo.http.sample.user.NameData nameData)", null, true);
-    actionGetUsers = new Action(3, "GET", "/users", "queryUsers()", null, true);
-    actionGetUser = new Action(4, "GET", "/users/{userId}", "queryUser(String userId)", null, true);
-    final Action actionGetUserEmailAddress = new Action(5, "GET", "/users/{userId}/emailAddresses/{emailAddressId}", "queryUserEmailAddress(String userId, String emailAddressId)", null, true);
+    actionPostUser = new Action(0, "POST", "/users", "register(body:io.vlingo.http.sample.user.UserData userData)", null);
+    actionPatchUserContact = new Action(1, "PATCH", "/users/{userId}/contact", "changeContact(String userId, body:io.vlingo.http.sample.user.ContactData contactData)", null);
+    actionPatchUserName = new Action(2, "PATCH", "/users/{userId}/name", "changeName(String userId, body:io.vlingo.http.sample.user.NameData nameData)", null);
+    actionGetUsers = new Action(3, "GET", "/users", "queryUsers()", null);
+    actionGetUser = new Action(4, "GET", "/users/{userId}", "queryUser(String userId)", null);
+    final Action actionGetUserEmailAddress = new Action(5, "GET", "/users/{userId}/emailAddresses/{emailAddressId}", "queryUserEmailAddress(String userId, String emailAddressId)", null);
 
     //=============================================================
     // this test assures that the optional feature used in the

--- a/src/test/java/io/vlingo/http/resource/ResourceDispatcherGeneratorTest.java
+++ b/src/test/java/io/vlingo/http/resource/ResourceDispatcherGeneratorTest.java
@@ -62,12 +62,12 @@ public class ResourceDispatcherGeneratorTest {
   @Before
   @SuppressWarnings("unchecked")
   public void setUp() {
-    actionPostUser = new Action(0, "POST", "/users", "register(body:io.vlingo.http.sample.user.UserData userData)", null, true);
-    actionPatchUserContact = new Action(1, "PATCH", "/users/{userId}/contact", "changeContact(String userId, body:io.vlingo.http.sample.user.ContactData contactData)", null, true);
-    actionPatchUserName = new Action(2, "PATCH", "/users/{userId}/name", "changeName(String userId, body:io.vlingo.http.sample.user.NameData nameData)", null, true);
-    actionGetUser = new Action(3, "GET", "/users/{userId}", "queryUser(String userId)", null, true);
-    actionGetUsers = new Action(4, "GET", "/users", "queryUsers()", null, true);
-    actionQueryUserError = new Action(5, "GET", "/users/{userId}/error", "queryUserError(String userId)", null, true);
+    actionPostUser = new Action(0, "POST", "/users", "register(body:io.vlingo.http.sample.user.UserData userData)", null);
+    actionPatchUserContact = new Action(1, "PATCH", "/users/{userId}/contact", "changeContact(String userId, body:io.vlingo.http.sample.user.ContactData contactData)", null);
+    actionPatchUserName = new Action(2, "PATCH", "/users/{userId}/name", "changeName(String userId, body:io.vlingo.http.sample.user.NameData nameData)", null);
+    actionGetUser = new Action(3, "GET", "/users/{userId}", "queryUser(String userId)", null);
+    actionGetUsers = new Action(4, "GET", "/users", "queryUsers()", null);
+    actionQueryUserError = new Action(5, "GET", "/users/{userId}/error", "queryUserError(String userId)", null);
 
     actions =
             Arrays.asList(

--- a/src/test/java/io/vlingo/http/resource/ResourceTestFixtures.java
+++ b/src/test/java/io/vlingo/http/resource/ResourceTestFixtures.java
@@ -142,12 +142,12 @@ public abstract class ResourceTestFixtures {
   public void setUp() throws Exception {
     world = World.start(WORLD_NAME);
 
-    actionPostUser = new Action(0, "POST", "/users", "register(body:io.vlingo.http.sample.user.UserData userData)", null, true);
-    actionPatchUserContact = new Action(1, "PATCH", "/users/{userId}/contact", "changeContact(String userId, body:io.vlingo.http.sample.user.ContactData contactData)", null, true);
-    actionPatchUserName = new Action(2, "PATCH", "/users/{userId}/name", "changeName(String userId, body:io.vlingo.http.sample.user.NameData nameData)", null, true);
-    actionGetUser = new Action(3, "GET", "/users/{userId}", "queryUser(String userId)", null, true);
-    actionGetUsers = new Action(4, "GET", "/users", "queryUsers()", null, true);
-    actionGetUserError = new Action(5, "GET", "/users/{userId}/error", "queryUserError(String userId)", null, true);
+    actionPostUser = new Action(0, "POST", "/users", "register(body:io.vlingo.http.sample.user.UserData userData)", null);
+    actionPatchUserContact = new Action(1, "PATCH", "/users/{userId}/contact", "changeContact(String userId, body:io.vlingo.http.sample.user.ContactData contactData)", null);
+    actionPatchUserName = new Action(2, "PATCH", "/users/{userId}/name", "changeName(String userId, body:io.vlingo.http.sample.user.NameData nameData)", null);
+    actionGetUser = new Action(3, "GET", "/users/{userId}", "queryUser(String userId)", null);
+    actionGetUsers = new Action(4, "GET", "/users", "queryUsers()", null);
+    actionGetUserError = new Action(5, "GET", "/users/{userId}/error", "queryUserError(String userId)", null);
 
 
     final List<Action> actions =

--- a/src/test/java/io/vlingo/http/resource/ResourcesTest.java
+++ b/src/test/java/io/vlingo/http/resource/ResourcesTest.java
@@ -97,15 +97,15 @@ public class ResourcesTest {
     final Resources resources =
             Resources
               .are(ConfigurationResource.defining("user", UserResource.class, 10,
-                      Actions.canBe("POST", "/users", "register(body:io.vlingo.http.sample.user.UserData userData)", true)
-                              .also("PATCH", "/users/{userId}/contact", "changeContact(String userId, body:io.vlingo.http.sample.user.ContactData contactData)", true)
-                              .also("PATCH", "/users/{userId}/name", "changeName(String userId, body:io.vlingo.http.sample.user.NameData nameData)", true)
-                              .also("GET", "/users/{userId}", "queryUser(String userId)", true)
-                              .also("GET", "/users", "queryUsers()", true)
+                      Actions.canBe("POST", "/users", "register(body:io.vlingo.http.sample.user.UserData userData)")
+                              .also("PATCH", "/users/{userId}/contact", "changeContact(String userId, body:io.vlingo.http.sample.user.ContactData contactData)")
+                              .also("PATCH", "/users/{userId}/name", "changeName(String userId, body:io.vlingo.http.sample.user.NameData nameData)")
+                              .also("GET", "/users/{userId}", "queryUser(String userId)")
+                              .also("GET", "/users", "queryUsers()")
                               .thatsAll()),
                    ConfigurationResource.defining("profile", ProfileResource.class, 5,
-                      Actions.canBe("PUT", "/users/{userId}/profile", "define(String userId, body:io.vlingo.http.sample.user.ProfileData profileData)", "io.vlingo.http.sample.user.ProfileDataMapper", false)
-                              .also("GET", "/users/{userId}/profile", "query(String userId)", "io.vlingo.http.sample.user.ProfileDataMapper", false)
+                      Actions.canBe("PUT", "/users/{userId}/profile", "define(String userId, body:io.vlingo.http.sample.user.ProfileData profileData)", "io.vlingo.http.sample.user.ProfileDataMapper")
+                              .also("GET", "/users/{userId}/profile", "query(String userId)", "io.vlingo.http.sample.user.ProfileDataMapper")
                               .thatsAll()));
 
     assertNotNull(resources.resourceOf("user"));
@@ -114,8 +114,8 @@ public class ResourcesTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testThatWrongIdSequenceBreaks() {
-    final Action actionPostUser = new Action(0, "POST", "/users", "register(body:io.vlingo.http.sample.user.UserData userData)", null, true);
-    final Action actionPatchUserContact = new Action(3, "PATCH", "/users/{userId}/contact", "changeContact(String userId, body:io.vlingo.http.sample.user.ContactData contactData)", null, true);
+    final Action actionPostUser = new Action(0, "POST", "/users", "register(body:io.vlingo.http.sample.user.UserData userData)", null);
+    final Action actionPatchUserContact = new Action(3, "PATCH", "/users/{userId}/contact", "changeContact(String userId, body:io.vlingo.http.sample.user.ContactData contactData)", null);
 
     final List<Action> actions = Arrays.asList(actionPostUser, actionPatchUserContact);
 
@@ -127,8 +127,8 @@ public class ResourcesTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testThatWrongIdOrderBreaks() {
-    final Action actionPostUser = new Action(3, "POST", "/users", "register(body:io.vlingo.http.sample.user.UserData userData)", null, true);
-    final Action actionPatchUserContact = new Action(1, "PATCH", "/users/{userId}/contact", "changeContact(String userId, body:io.vlingo.http.sample.user.ContactData contactData)", null, true);
+    final Action actionPostUser = new Action(3, "POST", "/users", "register(body:io.vlingo.http.sample.user.UserData userData)", null);
+    final Action actionPatchUserContact = new Action(1, "PATCH", "/users/{userId}/contact", "changeContact(String userId, body:io.vlingo.http.sample.user.ContactData contactData)", null);
 
     final List<Action> actions = Arrays.asList(actionPostUser, actionPatchUserContact);
 


### PR DESCRIPTION
Removes `Action.disallowPathParametersWithSlash` completely as discussed with @VaughnVernon.

Also adds a simple JMH benchmark (disabled by default) that can be used locally to measure the impact of refactorings to action matching.

Closes #52
Closes https://github.com/vlingo/vlingo-schemata/issues/63