### PR TITLE
Wait for the server and client shutdown in the unit tests

### DIFF
--- a/src/test/java/io/vlingo/http/resource/ClientTest.java
+++ b/src/test/java/io/vlingo/http/resource/ClientTest.java
@@ -7,24 +7,6 @@
 
 package io.vlingo.http.resource;
 
-import static io.vlingo.http.Method.POST;
-import static io.vlingo.http.RequestHeader.contentLength;
-import static io.vlingo.http.RequestHeader.host;
-import static io.vlingo.http.Response.Status.Created;
-import static io.vlingo.http.Response.Status.RequestTimeout;
-import static io.vlingo.http.ResponseHeader.Location;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import java.net.URI;
-import java.util.Map;
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.vlingo.actors.testkit.AccessSafely;
 import io.vlingo.http.Body;
 import io.vlingo.http.Request;
@@ -39,6 +21,23 @@ import io.vlingo.http.sample.user.model.User;
 import io.vlingo.wire.node.Address;
 import io.vlingo.wire.node.AddressType;
 import io.vlingo.wire.node.Host;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.vlingo.http.Method.POST;
+import static io.vlingo.http.RequestHeader.contentLength;
+import static io.vlingo.http.RequestHeader.host;
+import static io.vlingo.http.Response.Status.Created;
+import static io.vlingo.http.Response.Status.RequestTimeout;
+import static io.vlingo.http.ResponseHeader.Location;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class ClientTest extends ResourceTestFixtures {
   private static final Random random = new Random();
@@ -192,7 +191,7 @@ public class ClientTest extends ResourceTestFixtures {
 
   @Override
   @After
-  public void tearDown() {
+  public void tearDown() throws InterruptedException {
     if (client != null) client.close();
 
     if (server != null) server.stop();

--- a/src/test/java/io/vlingo/http/resource/ResourceFailureTest.java
+++ b/src/test/java/io/vlingo/http/resource/ResourceFailureTest.java
@@ -7,14 +7,6 @@
 
 package io.vlingo.http.resource;
 
-import java.nio.ByteBuffer;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.vlingo.actors.World;
 import io.vlingo.actors.testkit.AccessSafely;
 import io.vlingo.http.Filters;
@@ -29,6 +21,13 @@ import io.vlingo.wire.message.Converters;
 import io.vlingo.wire.node.Address;
 import io.vlingo.wire.node.AddressType;
 import io.vlingo.wire.node.Host;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class ResourceFailureTest {
   private static final AtomicInteger nextPort = new AtomicInteger(14000);
@@ -88,8 +87,12 @@ public class ResourceFailureTest {
   }
 
   @After
-  public void tearDown() {
+  public void tearDown() throws InterruptedException {
+    client.close();
+    
     server.shutDown();
+
+    Thread.sleep(200);
 
     world.terminate();
   }

--- a/src/test/java/io/vlingo/http/resource/ResourceTestFixtures.java
+++ b/src/test/java/io/vlingo/http/resource/ResourceTestFixtures.java
@@ -7,17 +7,6 @@
 
 package io.vlingo.http.resource;
 
-import static io.vlingo.common.serialization.JsonSerialization.serialized;
-
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.junit.After;
-import org.junit.Before;
-
 import io.vlingo.actors.World;
 import io.vlingo.http.sample.user.ContactData;
 import io.vlingo.http.sample.user.NameData;
@@ -25,6 +14,16 @@ import io.vlingo.http.sample.user.UserData;
 import io.vlingo.http.sample.user.model.UserRepository;
 import io.vlingo.wire.message.ByteBufferAllocator;
 import io.vlingo.wire.message.Converters;
+import org.junit.After;
+import org.junit.Before;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.vlingo.common.serialization.JsonSerialization.serialized;
 
 public abstract class ResourceTestFixtures {
   public static final String WORLD_NAME = "resource-test";
@@ -182,7 +181,10 @@ public abstract class ResourceTestFixtures {
   }
 
   @After
-  public void tearDown() {
+  public void tearDown() throws InterruptedException {
+    //wait for the tearDown overridden implementations to end
+    Thread.sleep(200);
+
     world.terminate();
 
     UserRepository.reset();

--- a/src/test/java/io/vlingo/http/resource/ServerTest.java
+++ b/src/test/java/io/vlingo/http/resource/ServerTest.java
@@ -183,14 +183,11 @@ public class ServerTest extends ResourceTestFixtures {
 
   @Override
   @After
-  public void tearDown() {
+  public void tearDown() throws InterruptedException {
     client.close();
 
-    server.shutDown(); // TODO: wait
-//    if (!server.shutDown().await(2000)) {
-//      System.out.println("Server did not shut down properly.");
-//    }
-
+    server.shutDown();
+    
     super.tearDown();
   }
 }

--- a/src/test/java/io/vlingo/http/resource/StaticFilesResourceTest.java
+++ b/src/test/java/io/vlingo/http/resource/StaticFilesResourceTest.java
@@ -20,6 +20,7 @@ import io.vlingo.wire.message.Converters;
 import io.vlingo.wire.node.Address;
 import io.vlingo.wire.node.AddressType;
 import io.vlingo.wire.node.Host;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -182,6 +183,18 @@ public class StaticFilesResourceTest {
     progress = new Progress();
     consumer = world.actorFor(ResponseChannelConsumer.class, Definition.has(TestResponseChannelConsumer.class, Definition.parameters(progress)));
     client = new NettyClientRequestResponseChannel(Address.from(Host.of("localhost"), serverPort, AddressType.NONE), consumer, 100, 10240);
+  }
+
+
+  @After
+  public void tearDown() throws Exception {
+    this.client.close();
+
+    this.server.shutDown();
+
+    Thread.sleep(200);
+    
+    this.world.terminate();
   }
 
   private String getRequest(final String filePath) {


### PR DESCRIPTION
Wait for the server and client shutdown in the unit tests tearDown method. Otherwise the world will be terminated before the stop() messages will get delivered to corresponding actors, leaving resources opened