### PR TITLE
ResourceHandler stage for dynamic resources

### DIFF
--- a/src/main/java/io/vlingo/http/resource/ResourceHandler.java
+++ b/src/main/java/io/vlingo/http/resource/ResourceHandler.java
@@ -48,6 +48,14 @@ public abstract class ResourceHandler {
   }
 
   /**
+   * Construct my default state with a {@code Stage}.
+   * @param stage the Stage to set as my stage
+   */
+  protected ResourceHandler(Stage stage) {
+    this.stage = stage;
+  }
+
+  /**
    * Answer my {@code completes}.
    * @return CompletesEventually
    */


### PR DESCRIPTION
Allows this on `public class SomeResource extends ResourceHandler`:
![super(stage); logger().info("should work");](https://user-images.githubusercontent.com/65456722/96850713-6d190a80-1457-11eb-839a-b3ccd24dea9e.png)
If there is a better way to set the `stage`, let me know.