### PR TITLE
Make SseStreamResource tests independent

### DIFF
--- a/src/test/java/io/vlingo/http/resource/sse/MockResponseSenderChannel.java
+++ b/src/test/java/io/vlingo/http/resource/sse/MockResponseSenderChannel.java
@@ -24,13 +24,14 @@ public class MockResponseSenderChannel implements ResponseSenderChannel {
   public AtomicReference<Response> eventsResponse = new AtomicReference<>();
   public AtomicInteger respondWithCount = new AtomicInteger(0);
   public AtomicReference<Response> response = new AtomicReference<>();
-  private AccessSafely abandonSafely = AccessSafely.afterCompleting(0);
-  private AccessSafely respondWithSafely = AccessSafely.afterCompleting(0);
+  private AccessSafely abandonSafely;
+  private AccessSafely respondWithSafely;
 
   private boolean receivedStatus;
 
   public MockResponseSenderChannel() {
     respondWithSafely = expectRespondWith(0);
+    abandonSafely = expectAbandon(0);
     receivedStatus = false;
   }
 

--- a/src/test/java/io/vlingo/http/resource/sse/SseFeedTest.java
+++ b/src/test/java/io/vlingo/http/resource/sse/SseFeedTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -72,5 +73,11 @@ public class SseFeedTest {
     Configuration.define();
     context = new MockRequestResponseContext(new MockResponseSenderChannel());
     client = new SseClient(context);
+  }
+
+  @After
+  public void tearDown() {
+    client.close();
+    world.terminate();
   }
 }


### PR DESCRIPTION
The map of publishers in `SseStreamResource` is static:

https://github.com/vlingo/vlingo-http/blob/a9f165564413d807086ce8d06ce277f2cc288024/src/main/java/io/vlingo/http/resource/sse/SseStreamResource.java#L39

The `publisherFor` method will not register a new publisher for the same stream name:

https://github.com/vlingo/vlingo-http/blob/a9f165564413d807086ce8d06ce277f2cc288024/src/main/java/io/vlingo/http/resource/sse/SseStreamResource.java#L73-L84

Before this fix, all tests were using the publisher registered by the first run test. 

The problem has not been evident until tearDown() phase was added with cleanup steps.

