### PR TITLE
Send the content length header with empty responses

### DIFF
--- a/src/main/java/io/vlingo/http/Response.java
+++ b/src/main/java/io/vlingo/http/Response.java
@@ -155,10 +155,9 @@ public class Response {
 
   private Headers<ResponseHeader> addMissingContentLengthHeader(final Headers<ResponseHeader> headers) {
     if (!entity.isComplex()) {
-      final int contentLength = entity.content().length();
       final Header header = headers.headerOf(ResponseHeader.ContentLength);
-      if (header == null && contentLength > 0) {
-        headers.add(ResponseHeader.of(ResponseHeader.ContentLength, Integer.toString(contentLength)));
+      if (header == null && !status.isInformational() && status != Status.NoContent && status != Status.NotModified) {
+        headers.add(ResponseHeader.of(ResponseHeader.ContentLength, Integer.toString(entity.content().length())));
       }
     }
     return headers;
@@ -277,6 +276,10 @@ public class Response {
         }
       }
       throw new IllegalArgumentException("status " + value + " is not valid");
+    }
+
+    private boolean isInformational() {
+      return String.valueOf(code).startsWith("1");
     }
   }
 }

--- a/src/test/java/io/vlingo/http/ResponseTest.java
+++ b/src/test/java/io/vlingo/http/ResponseTest.java
@@ -7,7 +7,7 @@
 
 package io.vlingo.http;
 
-import static io.vlingo.http.Response.Status.Ok;
+import static io.vlingo.http.Response.Status.*;
 import static io.vlingo.http.ResponseHeader.*;
 import static io.vlingo.http.ResponseHeader.ContentLength;
 import static org.junit.Assert.assertEquals;
@@ -20,7 +20,7 @@ public class ResponseTest {
   public void testResponseWithOneHeaderNoEntity() {
     final Response response = Response.of(Version.Http1_1, Ok, headers(CacheControl, "max-age=3600"));
 
-    final String facsimile = "HTTP/1.1 200 OK\nCache-Control: max-age=3600\n\n";
+    final String facsimile = "HTTP/1.1 200 OK\nCache-Control: max-age=3600\nContent-Length: 0\n\n";
 
     assertEquals(facsimile, response.toString());
   }
@@ -52,7 +52,7 @@ public class ResponseTest {
   public void testResponseWithMultipleHeadersNoEntity() {
     final Response response = Response.of(Version.Http1_1, Ok, headers(of(ETag, "123ABC")).and(of(CacheControl, "max-age=3600")));
 
-    final String facsimile = "HTTP/1.1 200 OK\nETag: 123ABC\nCache-Control: max-age=3600\n\n";
+    final String facsimile = "HTTP/1.1 200 OK\nETag: 123ABC\nCache-Control: max-age=3600\nContent-Length: 0\n\n";
 
     assertEquals(facsimile, response.toString());
   }
@@ -84,6 +84,33 @@ public class ResponseTest {
                     Body.beginChunked().appendChunk(Chunk1).appendChunk(Chunk2).end());
 
     assertEquals(responseMultiHeadersWithChunkedBody, response.toString());
+  }
+
+  @Test
+  public void testItShouldSendNoContentLengthWithInformationalStatusCodes() {
+    final Response response = Response.of(Version.Http1_1, Continue);
+
+    final String facsimile = "HTTP/1.1 100 Continue\n\n";
+
+    assertEquals(facsimile, response.toString());
+  }
+
+  @Test
+  public void testItShouldSendNoContentLengthWithNoContentStatusCode() {
+    final Response response = Response.of(Version.Http1_1, NoContent);
+
+    final String facsimile = "HTTP/1.1 204 No Content\n\n";
+
+    assertEquals(facsimile, response.toString());
+  }
+
+  @Test
+  public void testItShouldSendNoContentLengthWithNotModifiedStatusCode() {
+    final Response response = Response.of(Version.Http1_1, NotModified);
+
+    final String facsimile = "HTTP/1.1 304 Not Modified\n\n";
+
+    assertEquals(facsimile, response.toString());
   }
 }
 


### PR DESCRIPTION
Fixes #74 

The behaviour I observed is http clients (including browsers) hang waiting for response body when there is no `Content-Length` header in the response.

# RFC 7230

https://tools.ietf.org/html/rfc7230#section-3.3.2

When a message does not have a Transfer-Encoding header field, a Content-Length header field can provide the anticipated size, as a decimal number of octets, for a potential payload body. For messages that do include a payload body, the Content-Length field-value provides the framing information necessary for determining where the body (and message) ends. For messages that do not include a payload body, the Content-Length indicates the size of the selected representation (Section 3 of [RFC7231]).

# 1xx and 204

A server MUST NOT send a Content-Length header field in any response with a status code of 1xx (Informational) or 204 (No Content).  A server MUST NOT send a Content-Length header field in any 2xx (Successful) response to a CONNECT request (Section 4.3.6 of [RFC7231]).

# 304

A server MAY send a Content-Length header field in a 304 (Not Modified) response to a conditional GET request (Section 4.1 of [RFC7232]); a server MUST NOT send Content-Length in such a response unless its field-value equals the decimal number of octets that would have been sent in the payload body of a 200 (OK) response to the same request.

# Other status codes

Aside from the cases defined above, in the absence of Transfer-Encoding, an origin server SHOULD send a Content-Length header field when the payload body size is known prior to sending the complete header section.  This will allow downstream recipients to measure transfer progress, know when a received message is complete, and potentially reuse the connection for additional requests.